### PR TITLE
fix: Carbon Analysis and dashboard polish #1

### DIFF
--- a/cards/uk-carbon-comparison-card.js
+++ b/cards/uk-carbon-comparison-card.js
@@ -1,0 +1,367 @@
+/**
+ * UK Carbon Intensity Comparison Card for Home Assistant
+ *
+ * Shows all 14 UK DNO regions side by side with current intensity,
+ * 24h average, and 48h average. User's region is highlighted.
+ */
+
+const INTENSITY_COLORS = {
+  "very low": "#1B9E77",
+  "very_low": "#1B9E77",
+  "low": "#66C2A5",
+  "moderate": "#FFD92F",
+  "high": "#FC8D62",
+  "very high": "#E5584F",
+  "very_high": "#E5584F",
+};
+
+function getIndexFromValue(value) {
+  if (value < 40) return "very low";
+  if (value < 80) return "low";
+  if (value < 180) return "moderate";
+  if (value < 280) return "high";
+  return "very high";
+}
+
+function getColorFromValue(value) {
+  return INTENSITY_COLORS[getIndexFromValue(value)] || "#999";
+}
+
+function getColorFromIndex(index) {
+  if (!index) return "#999";
+  return INTENSITY_COLORS[index.toLowerCase()] || "#999";
+}
+
+const SORT_MODES = [
+  { key: "current", label: "Now" },
+  { key: "avg_24h", label: "24h Avg" },
+  { key: "avg_48h", label: "48h Avg" },
+];
+
+class UKCarbonComparisonCard extends HTMLElement {
+  static getConfigElement() {
+    return document.createElement("uk-carbon-comparison-card-editor");
+  }
+
+  static getStubConfig(hass) {
+    const entities = Object.keys(hass.states).filter(
+      (e) => e.startsWith("sensor.") && e.endsWith("_regional_comparison")
+    );
+    return { entity: entities[0] || "" };
+  }
+
+  constructor() {
+    super();
+    this._sortIndex = 0;
+  }
+
+  set hass(hass) {
+    this._hass = hass;
+    this._render();
+  }
+
+  setConfig(config) {
+    this._config = config;
+    if (!this._config.entity) {
+      this._autoDiscover = true;
+    }
+  }
+
+  getCardSize() {
+    return 10;
+  }
+
+  _getEntity() {
+    if (!this._hass) return null;
+    if (this._config.entity && this._hass.states[this._config.entity]) {
+      return this._hass.states[this._config.entity];
+    }
+    if (this._autoDiscover) {
+      const key = Object.keys(this._hass.states).find(
+        (e) => e.startsWith("sensor.") && e.endsWith("_regional_comparison")
+      );
+      if (key) return this._hass.states[key];
+    }
+    return null;
+  }
+
+  _render() {
+    if (!this.shadowRoot) {
+      this.attachShadow({ mode: "open" });
+    }
+
+    const entity = this._getEntity();
+
+    if (
+      !entity ||
+      entity.state === "unavailable" ||
+      entity.state === "unknown"
+    ) {
+      this.shadowRoot.innerHTML = `
+        <ha-card>
+          <style>
+            .unavailable {
+              padding: 24px;
+              text-align: center;
+              color: var(--secondary-text-color);
+              font-size: 14px;
+            }
+          </style>
+          <div class="unavailable">
+            ${!entity ? "No regional comparison entity found" : "Data unavailable"}
+          </div>
+        </ha-card>
+      `;
+      return;
+    }
+
+    const attrs = entity.attributes || {};
+    const regions = attrs.regions || [];
+    const userRegionId = attrs.user_regionid;
+    const sortMode = SORT_MODES[this._sortIndex];
+
+    // Sort regions
+    const sorted = [...regions].sort((a, b) => {
+      const aVal = sortMode.key === "current" ? a.current : a[sortMode.key];
+      const bVal = sortMode.key === "current" ? b.current : b[sortMode.key];
+      return aVal - bVal;
+    });
+
+    this.shadowRoot.innerHTML = `
+      <ha-card>
+        <style>${this._getStyles()}</style>
+        <div class="card-content">
+          <div class="header">
+            <div class="header-left">
+              <svg class="header-icon" viewBox="0 0 24 24">
+                <path fill="currentColor"
+                  d="M12,2C8.13,2,5,5.13,5,9c0,5.25,7,13,7,13s7-7.75,7-13C19,5.13,15.87,2,12,2z
+                     M12,11.5c-1.38,0-2.5-1.12-2.5-2.5s1.12-2.5,2.5-2.5s2.5,1.12,2.5,2.5
+                     S13.38,11.5,12,11.5z"/>
+              </svg>
+              UK Regional Comparison
+            </div>
+            <button class="sort-btn" id="sort-toggle">
+              Sort: ${sortMode.label} ▼
+            </button>
+          </div>
+          <div class="table-wrapper">
+            <table>
+              <thead>
+                <tr>
+                  <th class="col-region">Region</th>
+                  <th class="col-value">Now</th>
+                  <th class="col-value">24h Avg</th>
+                  <th class="col-value">48h Avg</th>
+                </tr>
+              </thead>
+              <tbody>
+                ${sorted.map((r) => this._renderRow(r, userRegionId)).join("")}
+              </tbody>
+            </table>
+          </div>
+        </div>
+      </ha-card>
+    `;
+
+    this.shadowRoot
+      .getElementById("sort-toggle")
+      .addEventListener("click", () => {
+        this._sortIndex = (this._sortIndex + 1) % SORT_MODES.length;
+        this._render();
+      });
+  }
+
+  _renderRow(region, userRegionId) {
+    const isUser = region.regionid === userRegionId;
+    const rowClass = isUser ? "region-row user-region" : "region-row";
+    const star = isUser ? "★ " : "";
+    const currentColor = getColorFromIndex(region.index);
+    const avg24Color = getColorFromValue(region.avg_24h);
+    const avg48Color = getColorFromValue(region.avg_48h);
+
+    return `
+      <tr class="${rowClass}">
+        <td class="col-region">${star}${region.shortname}</td>
+        <td class="col-value">
+          <span class="badge" style="background:${currentColor}">${region.current}</span>
+        </td>
+        <td class="col-value">
+          <span class="badge" style="background:${avg24Color}">${Math.round(region.avg_24h)}</span>
+        </td>
+        <td class="col-value">
+          <span class="badge" style="background:${avg48Color}">${Math.round(region.avg_48h)}</span>
+        </td>
+      </tr>
+    `;
+  }
+
+  _getStyles() {
+    return `
+      :host {
+        --ci-text: var(--primary-text-color, #333);
+        --ci-text-secondary: var(--secondary-text-color, #666);
+        --ci-divider: var(--divider-color, rgba(0,0,0,0.12));
+      }
+      .card-content {
+        padding: 16px;
+      }
+      .header {
+        display: flex;
+        align-items: center;
+        justify-content: space-between;
+        margin-bottom: 12px;
+      }
+      .header-left {
+        display: flex;
+        align-items: center;
+        gap: 8px;
+        font-size: 16px;
+        font-weight: 500;
+        color: var(--ci-text);
+      }
+      .header-icon {
+        width: 24px;
+        height: 24px;
+        color: #66C2A5;
+      }
+      .sort-btn {
+        background: none;
+        border: 1px solid var(--ci-divider);
+        border-radius: 6px;
+        padding: 4px 10px;
+        font-size: 12px;
+        color: var(--ci-text-secondary);
+        cursor: pointer;
+        font-family: inherit;
+      }
+      .sort-btn:hover {
+        background: var(--ci-divider);
+      }
+      .table-wrapper {
+        overflow-x: auto;
+      }
+      table {
+        width: 100%;
+        border-collapse: collapse;
+        font-size: 13px;
+      }
+      thead th {
+        text-align: center;
+        font-size: 11px;
+        font-weight: 600;
+        color: var(--ci-text-secondary);
+        text-transform: uppercase;
+        letter-spacing: 0.5px;
+        padding: 6px 4px;
+        border-bottom: 2px solid var(--ci-divider);
+      }
+      thead th.col-region {
+        text-align: left;
+      }
+      .region-row td {
+        padding: 5px 4px;
+        border-bottom: 1px solid var(--ci-divider);
+      }
+      .col-region {
+        text-align: left;
+        color: var(--ci-text);
+        white-space: nowrap;
+      }
+      .col-value {
+        text-align: center;
+        width: 70px;
+      }
+      .user-region td {
+        font-weight: 700;
+        background: rgba(102, 194, 165, 0.12);
+      }
+      .user-region td.col-region {
+        color: #1B9E77;
+      }
+      .badge {
+        display: inline-block;
+        min-width: 32px;
+        padding: 2px 6px;
+        border-radius: 8px;
+        font-size: 12px;
+        font-weight: 600;
+        color: #fff;
+        text-align: center;
+        font-variant-numeric: tabular-nums;
+      }
+    `;
+  }
+}
+
+// Card editor
+class UKCarbonComparisonCardEditor extends HTMLElement {
+  set hass(hass) {
+    this._hass = hass;
+    if (!this._rendered) this._render();
+  }
+
+  setConfig(config) {
+    this._config = { ...config };
+    if (this._rendered) this._render();
+  }
+
+  _render() {
+    this._rendered = true;
+    if (!this.shadowRoot) {
+      this.attachShadow({ mode: "open" });
+    }
+    this.shadowRoot.innerHTML = `
+      <style>
+        .editor { padding: 16px; }
+        label { display: block; margin-bottom: 4px; font-weight: 500; font-size: 14px; }
+        input {
+          width: 100%;
+          padding: 8px;
+          border: 1px solid var(--divider-color, #ccc);
+          border-radius: 4px;
+          box-sizing: border-box;
+          font-size: 14px;
+          background: var(--card-background-color, #fff);
+          color: var(--primary-text-color, #333);
+        }
+        .hint {
+          font-size: 12px;
+          color: var(--secondary-text-color, #666);
+          margin-top: 4px;
+        }
+      </style>
+      <div class="editor">
+        <label>Entity</label>
+        <input type="text"
+               value="${this._config.entity || ""}"
+               placeholder="sensor.uk_carbon_intensity_regional_comparison" />
+        <div class="hint">Leave blank to auto-discover</div>
+      </div>
+    `;
+
+    this.shadowRoot.querySelector("input").addEventListener("input", (e) => {
+      this._config = { ...this._config, entity: e.target.value };
+      this.dispatchEvent(
+        new CustomEvent("config-changed", { detail: { config: this._config } })
+      );
+    });
+  }
+}
+
+customElements.define("uk-carbon-comparison-card", UKCarbonComparisonCard);
+customElements.define(
+  "uk-carbon-comparison-card-editor",
+  UKCarbonComparisonCardEditor
+);
+
+window.customCards = window.customCards || [];
+window.customCards.push({
+  type: "uk-carbon-comparison-card",
+  name: "UK Carbon Intensity (Regional Comparison)",
+  description:
+    "Compare carbon intensity across all 14 UK DNO regions with current, 24h and 48h averages.",
+  preview: true,
+  documentationURL:
+    "https://www.home-assistant.io/integrations/uk_carbon_intensity",
+});

--- a/cards/uk-carbon-intensity-card.js
+++ b/cards/uk-carbon-intensity-card.js
@@ -1,0 +1,740 @@
+/**
+ * UK Carbon Intensity Card for Home Assistant
+ *
+ * Regional custom card: gauge, 48h forecast timeline, generation mix.
+ * Uses Lit (bundled with HA) for rendering. No external dependencies.
+ */
+
+const INTENSITY_COLORS = {
+  "very low": "#1B9E77",
+  "very_low": "#1B9E77",
+  "low": "#66C2A5",
+  "moderate": "#FFD92F",
+  "high": "#FC8D62",
+  "very high": "#E5584F",
+  "very_high": "#E5584F",
+};
+
+const FUEL_COLORS = {
+  wind: "#26A69A",
+  solar: "#FFD600",
+  nuclear: "#7E57C2",
+  gas: "#EF5350",
+  biomass: "#8D6E63",
+  imports: "#78909C",
+  hydro: "#42A5F5",
+  coal: "#424242",
+  other: "#BDBDBD",
+};
+
+const FUEL_ORDER = [
+  "gas",
+  "wind",
+  "biomass",
+  "nuclear",
+  "imports",
+  "solar",
+  "hydro",
+  "coal",
+  "other",
+];
+
+function getIntensityColor(index) {
+  if (!index) return "#999";
+  return INTENSITY_COLORS[index.toLowerCase()] || "#999";
+}
+
+function formatIndex(index) {
+  if (!index) return "";
+  return index.replace(/_/g, " ").replace(/\b\w/g, (c) => c.toUpperCase());
+}
+
+function formatTime(isoStr) {
+  const d = new Date(isoStr);
+  return d.toLocaleTimeString([], { hour: "2-digit", minute: "2-digit" });
+}
+
+class UKCarbonIntensityCard extends HTMLElement {
+  static getConfigElement() {
+    return document.createElement("uk-carbon-intensity-card-editor");
+  }
+
+  static getStubConfig(hass) {
+    const entities = Object.keys(hass.states).filter(
+      (e) =>
+        e.startsWith("sensor.") && e.endsWith("_regional_carbon_intensity")
+    );
+    return { entity: entities[0] || "" };
+  }
+
+  set hass(hass) {
+    this._hass = hass;
+    this._render();
+  }
+
+  setConfig(config) {
+    this._config = config;
+    if (!this._config.entity) {
+      this._autoDiscover = true;
+    }
+  }
+
+  getCardSize() {
+    return 8;
+  }
+
+  _getEntity() {
+    if (!this._hass) return null;
+    if (this._config.entity && this._hass.states[this._config.entity]) {
+      return this._hass.states[this._config.entity];
+    }
+    if (this._autoDiscover) {
+      const key = Object.keys(this._hass.states).find(
+        (e) =>
+          e.startsWith("sensor.") && e.endsWith("_regional_carbon_intensity")
+      );
+      if (key) return this._hass.states[key];
+    }
+    return null;
+  }
+
+  _render() {
+    if (!this.shadowRoot) {
+      this.attachShadow({ mode: "open" });
+    }
+
+    const entity = this._getEntity();
+
+    if (!entity || entity.state === "unavailable" || entity.state === "unknown") {
+      this.shadowRoot.innerHTML = `
+        <ha-card>
+          <style>
+            .unavailable {
+              padding: 24px;
+              text-align: center;
+              color: var(--secondary-text-color);
+              font-size: 14px;
+            }
+          </style>
+          <div class="unavailable">
+            ${!entity ? "No UK Carbon Intensity entity found" : "Data unavailable"}
+          </div>
+        </ha-card>
+      `;
+      return;
+    }
+
+    const attrs = entity.attributes || {};
+    const intensity = parseInt(entity.state, 10);
+    const index = this._getRegionalIndex();
+    const region = attrs.region || "";
+    const forecast = attrs.forecast || [];
+    const generationmix = attrs.generationmix || [];
+
+    // Compute low-carbon and fossil percentages
+    const lowCarbonFuels = ["wind", "solar", "nuclear", "hydro", "biomass"];
+    const fossilFuels = ["gas", "coal", "other"];
+    let lowCarbon = 0;
+    let fossil = 0;
+    for (const g of generationmix) {
+      if (lowCarbonFuels.includes(g.fuel)) lowCarbon += g.perc;
+      if (fossilFuels.includes(g.fuel)) fossil += g.perc;
+    }
+
+    // Find lowest forecast period
+    let lowestPeriod = null;
+    if (forecast.length > 0) {
+      lowestPeriod = forecast.reduce((min, p) =>
+        p.forecast < min.forecast ? p : min
+      );
+    }
+
+    this.shadowRoot.innerHTML = `
+      <ha-card>
+        <style>${this._getStyles()}</style>
+        <div class="card-content">
+          ${this._renderHeader(region)}
+          ${this._renderGaugeRow(intensity, index, lowestPeriod, lowCarbon, fossil)}
+          ${forecast.length > 0 ? this._renderForecast(forecast) : ""}
+          ${generationmix.length > 0 ? this._renderGenerationMix(generationmix) : ""}
+        </div>
+      </ha-card>
+    `;
+  }
+
+  _getRegionalIndex() {
+    if (!this._hass) return "";
+    const key = Object.keys(this._hass.states).find(
+      (e) => e.startsWith("sensor.") && e.endsWith("_regional_carbon_index")
+    );
+    return key ? this._hass.states[key].state : "";
+  }
+
+  _getStyles() {
+    return `
+      :host {
+        --ci-bg: var(--ha-card-background, var(--card-background-color, #fff));
+        --ci-text: var(--primary-text-color, #333);
+        --ci-text-secondary: var(--secondary-text-color, #666);
+        --ci-divider: var(--divider-color, rgba(0,0,0,0.12));
+      }
+      .card-content {
+        padding: 16px;
+      }
+      .header {
+        display: flex;
+        align-items: center;
+        justify-content: space-between;
+        margin-bottom: 16px;
+      }
+      .header-left {
+        display: flex;
+        align-items: center;
+        gap: 8px;
+        font-size: 16px;
+        font-weight: 500;
+        color: var(--ci-text);
+      }
+      .header-icon {
+        width: 24px;
+        height: 24px;
+        color: #66C2A5;
+      }
+      .region-label {
+        font-size: 13px;
+        color: var(--ci-text-secondary);
+        font-weight: 400;
+      }
+      .gauge-row {
+        display: flex;
+        align-items: center;
+        gap: 24px;
+        margin-bottom: 16px;
+      }
+      .gauge-container {
+        flex-shrink: 0;
+      }
+      .stats-panel {
+        flex: 1;
+        display: flex;
+        flex-direction: column;
+        gap: 6px;
+        font-size: 13px;
+        color: var(--ci-text);
+        min-width: 0;
+      }
+      .stat-row {
+        display: flex;
+        align-items: center;
+        gap: 6px;
+        white-space: nowrap;
+      }
+      .stat-label {
+        color: var(--ci-text-secondary);
+      }
+      .stat-badge {
+        display: inline-block;
+        padding: 1px 6px;
+        border-radius: 8px;
+        font-size: 11px;
+        font-weight: 500;
+        color: #fff;
+      }
+      .section {
+        border-top: 1px solid var(--ci-divider);
+        padding-top: 12px;
+        margin-top: 12px;
+      }
+      .section-title {
+        font-size: 12px;
+        font-weight: 500;
+        color: var(--ci-text-secondary);
+        text-transform: uppercase;
+        letter-spacing: 0.5px;
+        margin-bottom: 8px;
+      }
+      .forecast-chart {
+        width: 100%;
+        overflow: hidden;
+      }
+      .forecast-chart svg {
+        width: 100%;
+        display: block;
+      }
+      .forecast-detail {
+        max-height: 320px;
+        overflow-y: auto;
+        margin-top: 8px;
+        scrollbar-width: thin;
+      }
+      .forecast-day-label {
+        font-size: 11px;
+        font-weight: 600;
+        color: var(--ci-text);
+        padding: 6px 0 2px 0;
+        text-transform: uppercase;
+        letter-spacing: 0.3px;
+        border-bottom: 1px solid var(--ci-divider);
+        margin-bottom: 2px;
+        position: sticky;
+        top: 0;
+        background: var(--ci-bg);
+        z-index: 1;
+      }
+      .forecast-row {
+        display: flex;
+        align-items: center;
+        padding: 3px 0;
+        font-size: 12px;
+        gap: 8px;
+      }
+      .forecast-row.best-window {
+        background: rgba(27, 158, 119, 0.1);
+        border-radius: 4px;
+        padding: 3px 4px;
+      }
+      .forecast-time {
+        width: 90px;
+        flex-shrink: 0;
+        color: var(--ci-text-secondary);
+        font-variant-numeric: tabular-nums;
+      }
+      .forecast-bar-bg {
+        flex: 1;
+        height: 14px;
+        background: var(--ci-divider);
+        border-radius: 3px;
+        overflow: hidden;
+        position: relative;
+      }
+      .forecast-bar-fill {
+        height: 100%;
+        border-radius: 3px;
+        transition: width 0.3s;
+      }
+      .forecast-value {
+        width: 32px;
+        flex-shrink: 0;
+        text-align: right;
+        font-weight: 500;
+        font-variant-numeric: tabular-nums;
+        color: var(--ci-text);
+      }
+      .forecast-index-badge {
+        width: 62px;
+        flex-shrink: 0;
+        text-align: center;
+        font-size: 10px;
+        font-weight: 500;
+        color: #fff;
+        padding: 1px 4px;
+        border-radius: 6px;
+        white-space: nowrap;
+      }
+      .forecast-best-label {
+        font-size: 9px;
+        font-weight: 600;
+        color: #1B9E77;
+        text-transform: uppercase;
+        letter-spacing: 0.3px;
+      }
+      .mix-row {
+        display: flex;
+        align-items: flex-start;
+        gap: 16px;
+      }
+      .donut-container {
+        flex-shrink: 0;
+      }
+      .mix-legend {
+        flex: 1;
+        display: flex;
+        flex-direction: column;
+        gap: 4px;
+        font-size: 12px;
+        min-width: 0;
+      }
+      .legend-item {
+        display: flex;
+        align-items: center;
+        gap: 6px;
+      }
+      .legend-swatch {
+        width: 10px;
+        height: 10px;
+        border-radius: 2px;
+        flex-shrink: 0;
+      }
+      .legend-fuel {
+        flex: 1;
+        color: var(--ci-text);
+        text-transform: capitalize;
+      }
+      .legend-perc {
+        color: var(--ci-text-secondary);
+        min-width: 38px;
+        text-align: right;
+      }
+      .legend-bar-bg {
+        width: 50px;
+        height: 6px;
+        background: var(--ci-divider);
+        border-radius: 3px;
+        overflow: hidden;
+        flex-shrink: 0;
+      }
+      .legend-bar-fill {
+        height: 100%;
+        border-radius: 3px;
+      }
+    `;
+  }
+
+  _renderHeader(region) {
+    return `
+      <div class="header">
+        <div class="header-left">
+          <svg class="header-icon" viewBox="0 0 24 24">
+            <path fill="currentColor"
+              d="M12,2C6.48,2,2,6.48,2,12s4.48,10,10,10,10-4.48,10-10S17.52,2,12,2Z
+                 M12,20c-4.41,0-8-3.59-8-8s3.59-8,8-8,8,3.59,8,8-3.59,8-8,8Z
+                 M12.5,7H11v6l5.25,3.15.75-1.23-4.5-2.67Z"/>
+          </svg>
+          Regional Carbon Intensity
+        </div>
+        ${region ? `<span class="region-label">${region}</span>` : ""}
+      </div>
+    `;
+  }
+
+  _renderGaugeRow(intensity, index, lowestPeriod, lowCarbon, fossil) {
+    const color = getIntensityColor(index);
+    const gauge = this._renderGaugeSVG(intensity, index, color);
+
+    const lowestText = lowestPeriod
+      ? `${lowestPeriod.forecast} gCO2 at ${formatTime(lowestPeriod.from)}`
+      : "N/A";
+    const lowestBadge = lowestPeriod
+      ? `<span class="stat-badge" style="background:${getIntensityColor(lowestPeriod.index)}">${formatIndex(lowestPeriod.index)}</span>`
+      : "";
+
+    return `
+      <div class="gauge-row">
+        <div class="gauge-container">${gauge}</div>
+        <div class="stats-panel">
+          <div class="stat-row">
+            <span class="stat-label">Best window:</span>
+            <strong>${lowestText}</strong>
+            ${lowestBadge}
+          </div>
+          <div class="stat-row">
+            <span style="color:#66C2A5">&#9881;</span>
+            <span class="stat-label">Low carbon:</span>
+            <strong>${lowCarbon.toFixed(1)}%</strong>
+          </div>
+          <div class="stat-row">
+            <span style="color:#EF5350">&#9881;</span>
+            <span class="stat-label">Fossil:</span>
+            <strong>${fossil.toFixed(1)}%</strong>
+          </div>
+        </div>
+      </div>
+    `;
+  }
+
+  _renderGaugeSVG(value, index, color) {
+    const maxVal = 500;
+    const clamped = Math.min(Math.max(value, 0), maxVal);
+    const pct = clamped / maxVal;
+    const r = 50;
+    const cx = 60;
+    const cy = 60;
+
+    const arcPath = (startDeg, endDeg, radius) => {
+      const startRad = ((startDeg - 90) * Math.PI) / 180;
+      const endRad = ((endDeg - 90) * Math.PI) / 180;
+      const x1 = cx + radius * Math.cos(startRad);
+      const y1 = cy + radius * Math.sin(startRad);
+      const x2 = cx + radius * Math.cos(endRad);
+      const y2 = cy + radius * Math.sin(endRad);
+      const large = endDeg - startDeg > 180 ? 1 : 0;
+      return `M ${x1} ${y1} A ${radius} ${radius} 0 ${large} 1 ${x2} ${y2}`;
+    };
+
+    const startAngle = -135;
+    const endAngle = 135;
+    const range = endAngle - startAngle;
+    const valueAngle = startAngle + range * pct;
+
+    return `
+      <svg width="120" height="90" viewBox="0 0 120 90">
+        <path d="${arcPath(startAngle, endAngle, r)}"
+              fill="none" stroke="var(--ci-divider)" stroke-width="8"
+              stroke-linecap="round"/>
+        ${
+          pct > 0
+            ? `<path d="${arcPath(startAngle, valueAngle, r)}"
+              fill="none" stroke="${color}" stroke-width="8"
+              stroke-linecap="round"/>`
+            : ""
+        }
+        <text x="${cx}" y="${cy - 4}" text-anchor="middle"
+              font-size="22" font-weight="700"
+              fill="var(--ci-text)">${value}</text>
+        <text x="${cx}" y="${cy + 14}" text-anchor="middle"
+              font-size="11" font-weight="500"
+              fill="${color}">${formatIndex(index)}</text>
+      </svg>
+    `;
+  }
+
+  _renderForecast(forecast) {
+    const maxVal = Math.max(...forecast.map((p) => p.forecast), 100);
+    const lowestVal = Math.min(...forecast.map((p) => p.forecast));
+
+    // Group periods by day
+    const days = {};
+    for (const p of forecast) {
+      const d = new Date(p.from);
+      const key = d.toLocaleDateString([], { weekday: "short", month: "short", day: "numeric" });
+      if (!days[key]) days[key] = [];
+      days[key].push(p);
+    }
+
+    let rows = "";
+    for (const [dayLabel, periods] of Object.entries(days)) {
+      rows += `<div class="forecast-day-label">${dayLabel}</div>`;
+      for (const p of periods) {
+        const from = formatTime(p.from);
+        const to = formatTime(p.to);
+        const col = getIntensityColor(p.index);
+        const barPct = (p.forecast / maxVal) * 100;
+        const isBest = p.forecast === lowestVal;
+        const rowClass = isBest ? "forecast-row best-window" : "forecast-row";
+
+        rows += `
+          <div class="${rowClass}">
+            <span class="forecast-time">${from} - ${to}</span>
+            <div class="forecast-bar-bg">
+              <div class="forecast-bar-fill" style="width:${barPct}%;background:${col}"></div>
+            </div>
+            <span class="forecast-value">${p.forecast}</span>
+            <span class="forecast-index-badge" style="background:${col}">${formatIndex(p.index)}</span>
+            ${isBest ? '<span class="forecast-best-label">Best</span>' : ""}
+          </div>
+        `;
+      }
+    }
+
+    return `
+      <div class="section">
+        <div class="section-title">48h Forecast</div>
+        ${this._renderForecastChart(forecast, maxVal)}
+        <div class="forecast-detail">
+          ${rows}
+        </div>
+      </div>
+    `;
+  }
+
+  _renderForecastChart(forecast, maxVal) {
+    const svgW = 480;
+    const svgH = 60;
+    const barGap = 1;
+    const n = forecast.length;
+    const barW = Math.max((svgW - (n - 1) * barGap) / n, 2);
+    const topPad = 4;
+    const bottomPad = 14;
+    const chartH = svgH - topPad - bottomPad;
+
+    let bars = "";
+    for (let i = 0; i < n; i++) {
+      const p = forecast[i];
+      const x = i * (barW + barGap);
+      const h = (p.forecast / maxVal) * chartH;
+      const y = topPad + chartH - h;
+      const col = getIntensityColor(p.index);
+      bars += `<rect x="${x}" y="${y}" width="${barW}" height="${h}" fill="${col}" rx="1"/>`;
+    }
+
+    let labels = "";
+    let prevDay = "";
+    for (let i = 0; i < n; i++) {
+      const d = new Date(forecast[i].from);
+      const day = d.toLocaleDateString([], { weekday: "short" });
+      if (day !== prevDay) {
+        const x = i * (barW + barGap) + barW / 2;
+        labels += `<text x="${x}" y="${svgH - 1}" text-anchor="start"
+                         font-size="9" font-weight="500" fill="var(--ci-text-secondary)">${day}</text>`;
+        prevDay = day;
+      }
+    }
+
+    const totalW = n * (barW + barGap) - barGap;
+
+    return `
+      <div class="forecast-chart">
+        <svg viewBox="0 0 ${totalW} ${svgH}" preserveAspectRatio="none">
+          ${bars}
+          ${labels}
+        </svg>
+      </div>
+    `;
+  }
+
+  _renderGenerationMix(generationmix) {
+    const sorted = FUEL_ORDER
+      .map((fuel) => {
+        const match = generationmix.find((g) => g.fuel === fuel);
+        return match || { fuel, perc: 0 };
+      })
+      .filter((g) => g.perc > 0);
+
+    const donut = this._renderDonutSVG(sorted);
+    const maxPerc = Math.max(...sorted.map((g) => g.perc), 1);
+
+    let legendItems = "";
+    for (const g of sorted) {
+      const col = FUEL_COLORS[g.fuel] || "#BDBDBD";
+      const barPct = (g.perc / maxPerc) * 100;
+      legendItems += `
+        <div class="legend-item">
+          <div class="legend-swatch" style="background:${col}"></div>
+          <span class="legend-fuel">${g.fuel}</span>
+          <span class="legend-perc">${g.perc.toFixed(1)}%</span>
+          <div class="legend-bar-bg">
+            <div class="legend-bar-fill" style="width:${barPct}%;background:${col}"></div>
+          </div>
+        </div>
+      `;
+    }
+
+    return `
+      <div class="section">
+        <div class="section-title">Regional Generation Mix</div>
+        <div class="mix-row">
+          <div class="donut-container">${donut}</div>
+          <div class="mix-legend">${legendItems}</div>
+        </div>
+      </div>
+    `;
+  }
+
+  _renderDonutSVG(fuels) {
+    const cx = 50;
+    const cy = 50;
+    const r = 38;
+    const innerR = 24;
+    const total = fuels.reduce((s, g) => s + g.perc, 0);
+    if (total === 0) return "";
+
+    let segments = "";
+    let startAngle = -90;
+
+    for (const g of fuels) {
+      const sweep = (g.perc / total) * 360;
+      if (sweep < 0.5) continue;
+      const endAngle = startAngle + sweep;
+      const startRad = (startAngle * Math.PI) / 180;
+      const endRad = (endAngle * Math.PI) / 180;
+
+      const x1o = cx + r * Math.cos(startRad);
+      const y1o = cy + r * Math.sin(startRad);
+      const x2o = cx + r * Math.cos(endRad);
+      const y2o = cy + r * Math.sin(endRad);
+      const x1i = cx + innerR * Math.cos(endRad);
+      const y1i = cy + innerR * Math.sin(endRad);
+      const x2i = cx + innerR * Math.cos(startRad);
+      const y2i = cy + innerR * Math.sin(startRad);
+
+      const large = sweep > 180 ? 1 : 0;
+      const col = FUEL_COLORS[g.fuel] || "#BDBDBD";
+
+      segments += `<path d="M ${x1o} ${y1o}
+                            A ${r} ${r} 0 ${large} 1 ${x2o} ${y2o}
+                            L ${x1i} ${y1i}
+                            A ${innerR} ${innerR} 0 ${large} 0 ${x2i} ${y2i}
+                            Z"
+                        fill="${col}"/>`;
+      startAngle = endAngle;
+    }
+
+    return `
+      <svg width="100" height="100" viewBox="0 0 100 100">
+        ${segments}
+      </svg>
+    `;
+  }
+}
+
+// Card editor
+class UKCarbonIntensityCardEditor extends HTMLElement {
+  set hass(hass) {
+    this._hass = hass;
+    if (!this._rendered) this._render();
+  }
+
+  setConfig(config) {
+    this._config = { ...config };
+    if (this._rendered) this._render();
+  }
+
+  _render() {
+    this._rendered = true;
+    if (!this.shadowRoot) {
+      this.attachShadow({ mode: "open" });
+    }
+    this.shadowRoot.innerHTML = `
+      <style>
+        .editor { padding: 16px; }
+        label { display: block; margin-bottom: 4px; font-weight: 500; font-size: 14px; }
+        input {
+          width: 100%;
+          padding: 8px;
+          border: 1px solid var(--divider-color, #ccc);
+          border-radius: 4px;
+          box-sizing: border-box;
+          font-size: 14px;
+          background: var(--card-background-color, #fff);
+          color: var(--primary-text-color, #333);
+        }
+        .hint {
+          font-size: 12px;
+          color: var(--secondary-text-color, #666);
+          margin-top: 4px;
+        }
+      </style>
+      <div class="editor">
+        <label>Entity</label>
+        <input type="text"
+               value="${this._config.entity || ""}"
+               placeholder="sensor.uk_carbon_intensity_regional_carbon_intensity" />
+        <div class="hint">Leave blank to auto-discover</div>
+      </div>
+    `;
+
+    this.shadowRoot.querySelector("input").addEventListener("input", (e) => {
+      this._config = { ...this._config, entity: e.target.value };
+      this.dispatchEvent(
+        new CustomEvent("config-changed", { detail: { config: this._config } })
+      );
+    });
+  }
+}
+
+customElements.define("uk-carbon-intensity-card", UKCarbonIntensityCard);
+customElements.define(
+  "uk-carbon-intensity-card-editor",
+  UKCarbonIntensityCardEditor
+);
+
+window.customCards = window.customCards || [];
+window.customCards.push({
+  type: "uk-carbon-intensity-card",
+  name: "UK Carbon Intensity (Regional)",
+  description:
+    "Regional carbon intensity with gauge, 48h forecast timeline, and generation mix.",
+  preview: true,
+  documentationURL:
+    "https://www.home-assistant.io/integrations/uk_carbon_intensity",
+});

--- a/dashboards/energy-intelligence.yaml
+++ b/dashboards/energy-intelligence.yaml
@@ -69,7 +69,7 @@ views:
 
           - type: markdown
             content: |
-              ### Current Readings
+              ### Current Summary
               {% set import_rate = states('sensor.octopus_energy_OCTOPUS_IMPORT_current_rate') | float(0) %}
               {% set next_rate = states('sensor.octopus_energy_OCTOPUS_IMPORT_next_rate') | float(0) %}
               {% set export_rate = states('sensor.octopus_energy_OCTOPUS_EXPORT_export_current_rate') | float(0) %}

--- a/dashboards/energy-intelligence.yaml
+++ b/dashboards/energy-intelligence.yaml
@@ -100,6 +100,11 @@ views:
               {% set next_rate = states('sensor.octopus_energy_OCTOPUS_IMPORT_next_rate') | float(0) %}
               {% set export_rate = states('sensor.octopus_energy_OCTOPUS_EXPORT_export_current_rate') | float(0) %}
               {% set carbon_index = states('sensor.CARBON_national_index') %}
+              {% set carbon_intensity = states('sensor.CARBON_national_intensity') | float(0) %}
+              {% set low_carbon = states('sensor.CARBON_low_carbon_percentage') | float(0) %}
+              {% set fossil = states('sensor.CARBON_fossil_percentage') | float(0) %}
+              {% set wind = states('sensor.CARBON_generation_wind') | float(0) %}
+              {% set solar_gen = states('sensor.CARBON_generation_solar') | float(0) %}
               {% set battery_power = states('sensor.SOLAX_battery_power') | float(0) %}
               {% set grid_power = states('sensor.SOLAX_grid_power') | float(0) %}
               {% set solar_now = states('sensor.solcast_pv_forecast_power_now') | float(0) %}
@@ -109,7 +114,11 @@ views:
               | **Import rate** | {{ import_rate | round(2) }} p/kWh |
               | **Next rate** | {{ next_rate | round(2) }} p/kWh |
               | **Export rate** | {{ export_rate | round(2) }} p/kWh |
-              | **Carbon index** | {{ carbon_index }} |
+              | **Carbon intensity** | {{ carbon_intensity | round(0) | int }} gCO2/kWh ({{ carbon_index }}) |
+              | **Low-carbon generation** | {{ low_carbon | round(1) }}% |
+              | **Fossil fuel** | {{ fossil | round(1) }}% |
+              | **Wind** | {{ wind | round(1) }}% |
+              | **Solar (grid)** | {{ solar_gen | round(1) }}% |
               | **Battery power** | {{ battery_power | round(0) | int }} W |
               | **Grid power** | {{ grid_power | round(0) | int }} W |
               | **Solar forecast (now)** | {{ solar_now | round(0) | int }} W |
@@ -214,23 +223,6 @@ views:
               {% elif lowest_carbon < 200 %}
               Moderate grid carbon forecast ({{ lowest_carbon | round(0) | int }}gCO2/kWh).
               {% endif %}
-
-          - type: markdown
-            content: |
-              ### Carbon Forecast
-              {% set current = states('sensor.CARBON_national_intensity') | float(0) %}
-              {% set index = states('sensor.CARBON_national_index') %}
-              {% set low_carbon = states('sensor.CARBON_low_carbon_percentage') | float(0) %}
-              {% set fossil = states('sensor.CARBON_fossil_percentage') | float(0) %}
-              {% set wind = states('sensor.CARBON_generation_wind') | float(0) %}
-              {% set solar_gen = states('sensor.CARBON_generation_solar') | float(0) %}
-              | Metric | Value |
-              |--------|-------|
-              | **Current intensity** | {{ current | round(0) | int }}gCO2/kWh ({{ index }}) |
-              | **Low-carbon generation** | {{ low_carbon | round(1) }}% |
-              | **Fossil fuel** | {{ fossil | round(1) }}% |
-              | **Wind** | {{ wind | round(1) }}% |
-              | **Solar** | {{ solar_gen | round(1) }}% |
 
       # ── Section 4: Energy Ratios ──────────────────────────────────────
       - type: vertical-stack

--- a/dashboards/energy-intelligence.yaml
+++ b/dashboards/energy-intelligence.yaml
@@ -122,17 +122,14 @@ views:
           - type: markdown
             content: "## Yesterday's Review"
 
-          - type: horizontal-stack
-            cards:
-              - type: entity
-                entity: sensor.octopus_energy_OCTOPUS_IMPORT_previous_consumption
-                name: Consumption
-              - type: entity
-                entity: sensor.octopus_energy_OCTOPUS_IMPORT_previous_cost
-                name: Cost
-              - type: entity
-                entity: sensor.CARBON_national_intensity
-                name: Grid Carbon
+          - type: markdown
+            content: |
+              {% set consumption = states('sensor.octopus_energy_OCTOPUS_IMPORT_previous_consumption') | float(0) %}
+              {% set cost = states('sensor.octopus_energy_OCTOPUS_IMPORT_previous_cost') | float(0) %}
+              {% set carbon = states('sensor.CARBON_national_intensity') | float(0) %}
+              | Consumption | Cost | Grid Carbon |
+              |:-----------:|:----:|:-----------:|
+              | {{ consumption | round(1) }}kWh | £{{ '%.2f' | format(cost) }} | {{ carbon | round(0) | int }} gCO2/kWh |
 
           - type: markdown
             title: Carbon Analysis
@@ -187,17 +184,14 @@ views:
           - type: markdown
             content: "## Tomorrow's Outlook"
 
-          - type: horizontal-stack
-            cards:
-              - type: entity
-                entity: sensor.solcast_pv_forecast_forecast_today
-                name: Solar Today
-              - type: entity
-                entity: sensor.solcast_pv_forecast_forecast_tomorrow
-                name: Solar Tomorrow
-              - type: entity
-                entity: sensor.CARBON_lowest_forecast_intensity
-                name: Lowest Carbon
+          - type: markdown
+            content: |
+              {% set solar_today = states('sensor.solcast_pv_forecast_forecast_today') | float(0) %}
+              {% set solar_tomorrow = states('sensor.solcast_pv_forecast_forecast_tomorrow') | float(0) %}
+              {% set lowest_carbon = states('sensor.CARBON_lowest_forecast_intensity') | float(0) %}
+              | Solar Today | Solar Tomorrow | Lowest Carbon |
+              |:-----------:|:--------------:|:-------------:|
+              | {{ solar_today | round(1) }}kWh | {{ solar_tomorrow | round(1) }}kWh | {{ lowest_carbon | round(0) | int }} gCO2/kWh |
 
           - type: markdown
             title: Recommendation

--- a/dashboards/energy-intelligence.yaml
+++ b/dashboards/energy-intelligence.yaml
@@ -134,19 +134,16 @@ views:
               {% set elec_standing = states('sensor.octopus_energy_OCTOPUS_IMPORT_standing_charge') | float(0) / 100 %}
               {% set gas_standing = states('sensor.octopus_energy_OCTOPUS_GAS_gas_standing_charge') | float(0) / 100 %}
               {% set net = ic - export_revenue + gas_cost + elec_standing + gas_standing %}
-              {% set intensity = states('sensor.CARBON_national_intensity') | float(0) %}
-              {% set est_co2 = consumption * intensity %}
+              {% set co2_g = states('input_number.yesterday_co2_grams') | float(0) %}
               | | |
               |---|---:|
               | **Consumption** | {{ consumption | round(1) }} kWh |
-              | **Est. CO2 footprint** | {{ est_co2 | round(0) | int }}g ({{ (est_co2 / 1000) | round(2) }}kg) |
+              | **CO2 footprint** | {{ co2_g | round(0) | int }}g ({{ (co2_g / 1000) | round(2) }}kg) |
               | **Net daily cost** | **£{{ '%.2f' | format(net) }}** |
               | Electricity import | £{{ '%.2f' | format(ic) }} |
               | Export revenue | -£{{ '%.2f' | format(export_revenue) }} |
               | Gas | £{{ '%.2f' | format(gas_cost) }} |
               | Standing charges | £{{ '%.2f' | format(elec_standing + gas_standing) }} |
-
-              *CO2 estimate uses current grid intensity ({{ intensity | round(0) | int }}gCO2/kWh) as proxy for yesterday's average.*
               {% else %}
               *Awaiting yesterday's consumption data.*
               {% endif %}

--- a/dashboards/energy-intelligence.yaml
+++ b/dashboards/energy-intelligence.yaml
@@ -7,7 +7,7 @@
 #   OCTOPUS_IMPORT_*  — Electricity import meter sensors
 #   OCTOPUS_EXPORT_*  — Electricity export meter sensors
 #   OCTOPUS_GAS_*     — Gas meter sensors
-#   OCTOPUS_ENTRY_*   — Entry-level sensors (tariff_comparison, carbon_correlation)
+#   OCTOPUS_ENTRY_*   — Entry-level sensors (tariff_comparison)
 #   Solcast entities use fixed names (no placeholders needed)
 #   SOLAX_*           — SolaX inverter sensors
 #   CARBON_*          — UK Carbon Intensity sensors (discovered by translation_key)
@@ -131,43 +131,30 @@ views:
                 entity: sensor.octopus_energy_OCTOPUS_IMPORT_previous_cost
                 name: Cost
               - type: entity
-                entity: sensor.octopus_energy_OCTOPUS_ENTRY_carbon_correlation
-                name: Carbon Avg
+                entity: sensor.CARBON_national_intensity
+                name: Grid Carbon
 
           - type: markdown
             title: Carbon Analysis
             content: |
-              {% set carbon = state_attr('sensor.octopus_energy_OCTOPUS_ENTRY_carbon_correlation', 'carbon_summary') %}
-              {% if carbon %}
+              {% set consumption = states('sensor.octopus_energy_OCTOPUS_IMPORT_previous_consumption') | float(0) %}
+              {% set intensity = states('sensor.CARBON_national_intensity') | float(0) %}
+              {% set index = states('sensor.CARBON_national_index') %}
+              {% set low_carbon = states('sensor.CARBON_low_carbon_percentage') | float(0) %}
+              {% set fossil = states('sensor.CARBON_fossil_percentage') | float(0) %}
+              {% if consumption > 0 and intensity > 0 %}
+              {% set est_co2 = consumption * intensity %}
               | Metric | Value |
               |--------|-------|
-              | **Total CO2** | {{ carbon.total_grams_co2 | round(0) | int }}g ({{ (carbon.total_grams_co2 / 1000) | round(2) }}kg) |
-              | **Avg intensity** | {{ carbon.weighted_avg_intensity }}gCO2/kWh |
-              | **High-carbon usage** | {{ carbon.high_carbon_kwh }}kWh ({{ carbon.high_carbon_pct }}%) |
-              | **Low-carbon usage** | {{ carbon.low_carbon_kwh }}kWh ({{ carbon.low_carbon_pct }}%) |
-              {% else %}
-              *Carbon analysis will appear once the integration loads with consumption and carbon data.*
-              {% endif %}
+              | **Yesterday's import** | {{ consumption | round(1) }}kWh |
+              | **Est. CO2 footprint** | {{ est_co2 | round(0) | int }}g ({{ (est_co2 / 1000) | round(2) }}kg) |
+              | **Grid intensity (now)** | {{ intensity | round(0) | int }}gCO2/kWh ({{ index }}) |
+              | **Low-carbon share** | {{ low_carbon | round(1) }}% |
+              | **Fossil fuel share** | {{ fossil | round(1) }}% |
 
-          - type: markdown
-            title: Optimization Insights
-            content: |
-              {% set opt = state_attr('sensor.octopus_energy_OCTOPUS_ENTRY_carbon_correlation', 'optimization') %}
-              {% if opt and opt.cheapest_2h_window is defined %}
-              {% set cheap = opt.cheapest_2h_window %}
-              {% set green = opt.greenest_2h_window %}
-              **Cheapest 2h window yesterday:** {{ cheap.start[11:16] }}–{{ cheap.end[11:16] }} (avg {{ cheap.avg_rate }}p/kWh)
-
-              **Greenest 2h window yesterday:** {{ green.start[11:16] }}–{{ green.end[11:16] }} (avg {{ green.avg_intensity }}gCO2/kWh)
-
-              {% if cheap.start != green.start %}
-              *The cheapest and greenest windows differed — consider prioritising carbon or cost
-              depending on your goals.*
+              *CO2 estimate uses current grid intensity as proxy for yesterday's average.*
               {% else %}
-              *The cheapest window was also the greenest — optimal alignment!*
-              {% endif %}
-              {% else %}
-              *Optimization data will appear once the carbon correlation sensor has data.*
+              *Carbon analysis will appear once UK Carbon Intensity and consumption data are available.*
               {% endif %}
 
           - type: markdown

--- a/dashboards/energy-intelligence.yaml
+++ b/dashboards/energy-intelligence.yaml
@@ -93,25 +93,27 @@ views:
               **Normal operation** — {{ rate | round(1) }}p/kWh, carbon {{ carbon_index }}
               {% endif %}
 
-          - type: entities
-            title: Current Readings
-            entities:
-              - entity: sensor.octopus_energy_OCTOPUS_IMPORT_current_rate
-                name: Import rate
-              - entity: sensor.octopus_energy_OCTOPUS_IMPORT_next_rate
-                name: Next rate
-              - entity: sensor.octopus_energy_OCTOPUS_EXPORT_export_current_rate
-                name: Export rate
-              - entity: sensor.CARBON_national_index
-                name: Carbon index
-              - entity: sensor.SOLAX_battery_power
-                name: Battery power
-              - entity: sensor.SOLAX_grid_power
-                name: Grid power
-              - entity: sensor.solcast_pv_forecast_power_now
-                name: Solar forecast (now)
-              - entity: sensor.solcast_pv_forecast_forecast_remaining_today
-                name: Solar remaining today
+          - type: markdown
+            content: |
+              ### Current Readings
+              {% set import_rate = states('sensor.octopus_energy_OCTOPUS_IMPORT_current_rate') | float(0) %}
+              {% set next_rate = states('sensor.octopus_energy_OCTOPUS_IMPORT_next_rate') | float(0) %}
+              {% set export_rate = states('sensor.octopus_energy_OCTOPUS_EXPORT_export_current_rate') | float(0) %}
+              {% set carbon_index = states('sensor.CARBON_national_index') %}
+              {% set battery_power = states('sensor.SOLAX_battery_power') | float(0) %}
+              {% set grid_power = states('sensor.SOLAX_grid_power') | float(0) %}
+              {% set solar_now = states('sensor.solcast_pv_forecast_power_now') | float(0) %}
+              {% set solar_remaining = states('sensor.solcast_pv_forecast_forecast_remaining_today') | float(0) %}
+              | | |
+              |---|---:|
+              | **Import rate** | {{ import_rate | round(2) }} p/kWh |
+              | **Next rate** | {{ next_rate | round(2) }} p/kWh |
+              | **Export rate** | {{ export_rate | round(2) }} p/kWh |
+              | **Carbon index** | {{ carbon_index }} |
+              | **Battery power** | {{ battery_power | round(0) | int }} W |
+              | **Grid power** | {{ grid_power | round(0) | int }} W |
+              | **Solar forecast (now)** | {{ solar_now | round(0) | int }} W |
+              | **Solar remaining today** | {{ solar_remaining | round(1) }} kWh |
 
       # ── Section 2: Yesterday's Review ──────────────────────────────────
       - type: vertical-stack
@@ -267,8 +269,9 @@ views:
       # ── Section 5: Weekly Trends ──────────────────────────────────────
       - type: vertical-stack
         cards:
+          - type: markdown
+            content: "### PV Generation & Consumption (7 days)"
           - type: statistics-graph
-            title: PV Generation & Consumption (7 days)
             entities:
               - entity: sensor.SOLAX_total_pv_energy
                 name: PV Total
@@ -281,8 +284,9 @@ views:
               - change
             period: day
 
+          - type: markdown
+            content: "### Battery SOC (7 days)"
           - type: history-graph
-            title: Battery SOC (7 days)
             entities:
               - entity: sensor.SOLAX_battery_state_of_charge
                 name: Battery SOC

--- a/dashboards/energy-intelligence.yaml
+++ b/dashboards/energy-intelligence.yaml
@@ -126,10 +126,11 @@ views:
             content: |
               {% set consumption = states('sensor.octopus_energy_OCTOPUS_IMPORT_previous_consumption') | float(0) %}
               {% set cost = states('sensor.octopus_energy_OCTOPUS_IMPORT_previous_cost') | float(0) %}
-              {% set carbon = states('sensor.CARBON_national_intensity') | float(0) %}
-              | Consumption | Cost | Grid Carbon |
-              |:-----------:|:----:|:-----------:|
-              | {{ consumption | round(1) }}kWh | £{{ '%.2f' | format(cost) }} | {{ carbon | round(0) | int }} gCO2/kWh |
+              {% set intensity = states('sensor.CARBON_national_intensity') | float(0) %}
+              {% set est_co2 = consumption * intensity %}
+              | Consumption | Cost | Est. CO2 |
+              |:-----------:|:----:|:--------:|
+              | {{ consumption | round(1) }}kWh | £{{ '%.2f' | format(cost) }} | {{ est_co2 | round(0) | int }}g ({{ (est_co2 / 1000) | round(2) }}kg) |
 
           - type: markdown
             title: Carbon Analysis

--- a/dashboards/energy-intelligence.yaml
+++ b/dashboards/energy-intelligence.yaml
@@ -69,32 +69,6 @@ views:
 
           - type: markdown
             content: |
-              ### Smart Status
-              {% set rate = states('sensor.octopus_energy_OCTOPUS_IMPORT_current_rate') | float(0) %}
-              {% set carbon_index = states('sensor.CARBON_national_index') %}
-              {% set battery_soc = states('sensor.SOLAX_battery_state_of_charge') | float(0) %}
-              {% set grid_power = states('sensor.SOLAX_grid_power') | float(0) %}
-              {% set pv1 = states('sensor.SOLAX_pv1_power') | float(0) %}
-              {% set pv2 = states('sensor.SOLAX_pv2_power') | float(0) %}
-              {% set pv_total = pv1 + pv2 %}
-              {% if grid_power < -100 %}
-              **Exporting solar surplus** ({{ (grid_power | abs) | round(0) | int }}W to grid)
-              {% elif pv_total > 500 and battery_soc < 95 %}
-              **Charging battery from solar** ({{ pv_total | round(0) | int }}W PV)
-              {% elif rate > 25 and battery_soc > 20 %}
-              **Expensive period** — using battery ({{ battery_soc | round(0) | int }}% SOC)
-              {% elif carbon_index in ['high', 'very high'] %}
-              **High carbon grid** — defer heavy loads if possible
-              {% elif rate < 10 %}
-              **Cheap period** — good time for high-demand tasks
-              {% elif carbon_index in ['low', 'very low'] %}
-              **Clean grid** — carbon intensity is {{ carbon_index }}
-              {% else %}
-              **Normal operation** — {{ rate | round(1) }}p/kWh, carbon {{ carbon_index }}
-              {% endif %}
-
-          - type: markdown
-            content: |
               ### Current Readings
               {% set import_rate = states('sensor.octopus_energy_OCTOPUS_IMPORT_current_rate') | float(0) %}
               {% set next_rate = states('sensor.octopus_energy_OCTOPUS_IMPORT_next_rate') | float(0) %}
@@ -107,8 +81,28 @@ views:
               {% set solar_gen = states('sensor.CARBON_generation_solar') | float(0) %}
               {% set battery_power = states('sensor.SOLAX_battery_power') | float(0) %}
               {% set grid_power = states('sensor.SOLAX_grid_power') | float(0) %}
+              {% set battery_soc = states('sensor.SOLAX_battery_state_of_charge') | float(0) %}
+              {% set pv1 = states('sensor.SOLAX_pv1_power') | float(0) %}
+              {% set pv2 = states('sensor.SOLAX_pv2_power') | float(0) %}
+              {% set pv_total = pv1 + pv2 %}
               {% set solar_now = states('sensor.solcast_pv_forecast_power_now') | float(0) %}
               {% set solar_remaining = states('sensor.solcast_pv_forecast_forecast_remaining_today') | float(0) %}
+              {% if grid_power < -100 %}
+              **Exporting solar surplus** ({{ (grid_power | abs) | round(0) | int }}W to grid)
+              {% elif pv_total > 500 and battery_soc < 95 %}
+              **Charging battery from solar** ({{ pv_total | round(0) | int }}W PV)
+              {% elif import_rate > 25 and battery_soc > 20 %}
+              **Expensive period** — using battery ({{ battery_soc | round(0) | int }}% SOC)
+              {% elif carbon_index in ['high', 'very high'] %}
+              **High carbon grid** — defer heavy loads if possible
+              {% elif import_rate < 10 %}
+              **Cheap period** — good time for high-demand tasks
+              {% elif carbon_index in ['low', 'very low'] %}
+              **Clean grid** — carbon intensity is {{ carbon_index }}
+              {% else %}
+              **Normal operation** — {{ import_rate | round(1) }}p/kWh, carbon {{ carbon_index }}
+              {% endif %}
+
               | | |
               |---|---:|
               | **Import rate** | {{ import_rate | round(2) }} p/kWh |

--- a/dashboards/energy-intelligence.yaml
+++ b/dashboards/energy-intelligence.yaml
@@ -124,57 +124,29 @@ views:
           - type: markdown
             content: |
               ### Yesterday's Summary
-              {% set consumption = states('sensor.octopus_energy_OCTOPUS_IMPORT_previous_consumption') | float(0) %}
-              {% set cost = states('sensor.octopus_energy_OCTOPUS_IMPORT_previous_cost') | float(0) %}
-              {% set intensity = states('sensor.CARBON_national_intensity') | float(0) %}
-              {% set est_co2 = consumption * intensity %}
-              | Consumption | Cost | Est. CO2 |
-              |:-----------:|:----:|:--------:|
-              | {{ consumption | round(1) }}kWh | £{{ '%.2f' | format(cost) }} | {{ est_co2 | round(0) | int }}g ({{ (est_co2 / 1000) | round(2) }}kg) |
-
-          - type: markdown
-            content: |
-              ### Yesterday's Carbon Analysis
-              {% set consumption = states('sensor.octopus_energy_OCTOPUS_IMPORT_previous_consumption') | float(0) %}
-              {% set intensity = states('sensor.CARBON_national_intensity') | float(0) %}
-              {% set index = states('sensor.CARBON_national_index') %}
-              {% set low_carbon = states('sensor.CARBON_low_carbon_percentage') | float(0) %}
-              {% set fossil = states('sensor.CARBON_fossil_percentage') | float(0) %}
-              {% if consumption > 0 and intensity > 0 %}
-              {% set est_co2 = consumption * intensity %}
-              | Metric | Value |
-              |--------|-------|
-              | **Yesterday's import** | {{ consumption | round(1) }}kWh |
-              | **Est. CO2 footprint** | {{ est_co2 | round(0) | int }}g ({{ (est_co2 / 1000) | round(2) }}kg) |
-              | **Grid intensity (now)** | {{ intensity | round(0) | int }}gCO2/kWh ({{ index }}) |
-              | **Low-carbon share** | {{ low_carbon | round(1) }}% |
-              | **Fossil fuel share** | {{ fossil | round(1) }}% |
-
-              *CO2 estimate uses current grid intensity as proxy for yesterday's average.*
-              {% else %}
-              *Carbon analysis will appear once UK Carbon Intensity and consumption data are available.*
-              {% endif %}
-
-          - type: markdown
-            content: |
-              ### Yesterday's Net Cost
               {% set import_cost = states('sensor.octopus_energy_OCTOPUS_IMPORT_previous_cost') %}
               {% set has_data = import_cost not in ['unknown', 'unavailable'] %}
               {% if has_data %}
+              {% set consumption = states('sensor.octopus_energy_OCTOPUS_IMPORT_previous_consumption') | float(0) %}
               {% set ic = import_cost | float(0) %}
               {% set export_revenue = states('sensor.octopus_energy_OCTOPUS_EXPORT_export_previous_cost') | float(0) %}
               {% set gas_cost = states('sensor.octopus_energy_OCTOPUS_GAS_gas_previous_cost') | float(0) %}
               {% set elec_standing = states('sensor.octopus_energy_OCTOPUS_IMPORT_standing_charge') | float(0) / 100 %}
               {% set gas_standing = states('sensor.octopus_energy_OCTOPUS_GAS_gas_standing_charge') | float(0) / 100 %}
               {% set net = ic - export_revenue + gas_cost + elec_standing + gas_standing %}
-              **Net daily cost: £{{ '%.2f' | format(net) }}**
-
+              {% set intensity = states('sensor.CARBON_national_intensity') | float(0) %}
+              {% set est_co2 = consumption * intensity %}
               | | |
-              |---|---|
+              |---|---:|
+              | **Consumption** | {{ consumption | round(1) }} kWh |
+              | **Est. CO2 footprint** | {{ est_co2 | round(0) | int }}g ({{ (est_co2 / 1000) | round(2) }}kg) |
+              | **Net daily cost** | **£{{ '%.2f' | format(net) }}** |
               | Electricity import | £{{ '%.2f' | format(ic) }} |
               | Export revenue | -£{{ '%.2f' | format(export_revenue) }} |
               | Gas | £{{ '%.2f' | format(gas_cost) }} |
               | Standing charges | £{{ '%.2f' | format(elec_standing + gas_standing) }} |
+
+              *CO2 estimate uses current grid intensity ({{ intensity | round(0) | int }}gCO2/kWh) as proxy for yesterday's average.*
               {% else %}
               *Awaiting yesterday's consumption data.*
               {% endif %}

--- a/dashboards/energy-intelligence.yaml
+++ b/dashboards/energy-intelligence.yaml
@@ -265,29 +265,3 @@ views:
               |--------|-------|
               | **Clean energy** | {{ low_carbon | round(1) }}% |
               | **Fossil fuel** | {{ fossil | round(1) }}% |
-
-      # ── Section 5: Weekly Trends ──────────────────────────────────────
-      - type: vertical-stack
-        cards:
-          - type: markdown
-            content: "### PV Generation & Consumption (7 days)"
-          - type: statistics-graph
-            entities:
-              - entity: sensor.SOLAX_total_pv_energy
-                name: PV Total
-              - entity: sensor.octopus_energy_OCTOPUS_IMPORT_previous_consumption
-                name: Import
-              - entity: sensor.octopus_energy_OCTOPUS_EXPORT_export_previous_consumption
-                name: Export
-            days_to_show: 7
-            stat_types:
-              - change
-            period: day
-
-          - type: markdown
-            content: "### Battery SOC (7 days)"
-          - type: history-graph
-            entities:
-              - entity: sensor.SOLAX_battery_state_of_charge
-                name: Battery SOC
-            hours_to_show: 168

--- a/dashboards/energy-intelligence.yaml
+++ b/dashboards/energy-intelligence.yaml
@@ -157,19 +157,10 @@ views:
               {% set solar_today = states('sensor.solcast_pv_forecast_forecast_today') | float(0) %}
               {% set solar_tomorrow = states('sensor.solcast_pv_forecast_forecast_tomorrow') | float(0) %}
               {% set lowest_carbon = states('sensor.CARBON_lowest_forecast_intensity') | float(0) %}
+              {% set peak_tomorrow = states('sensor.solcast_pv_forecast_peak_forecast_tomorrow') | float(0) %}
               | Solar Today | Solar Tomorrow | Lowest Carbon |
               |:-----------:|:--------------:|:-------------:|
-              | {{ solar_today | round(1) }}kWh | {{ solar_tomorrow | round(1) }}kWh | {{ lowest_carbon | round(0) | int }} gCO2/kWh |
-
-          - type: markdown
-            content: |
-              ### Tomorrow's Recommendation
-              {% set solar_tomorrow = states('sensor.solcast_pv_forecast_forecast_tomorrow') | float(0) %}
-              {% set solar_today = states('sensor.solcast_pv_forecast_forecast_today') | float(0) %}
-              {% set lowest_carbon = states('sensor.CARBON_lowest_forecast_intensity') | float(0) %}
-              {% set battery_soc = states('sensor.SOLAX_battery_state_of_charge') | float(0) %}
-              {% set peak_tomorrow = states('sensor.solcast_pv_forecast_peak_forecast_tomorrow') | float(0) %}
-              **Tomorrow: {{ solar_tomorrow | round(1) }}kWh** (peak {{ (peak_tomorrow / 1000) | round(1) }}kW)
+              | {{ solar_today | round(1) }}kWh | {{ solar_tomorrow | round(1) }}kWh (peak {{ (peak_tomorrow / 1000) | round(1) }}kW) | {{ lowest_carbon | round(0) | int }} gCO2/kWh |
 
               {% if solar_tomorrow > 15 %}
               **Sunny day ahead** — skip overnight charging, solar should cover daytime needs and recharge the battery.

--- a/dashboards/energy-intelligence.yaml
+++ b/dashboards/energy-intelligence.yaml
@@ -20,9 +20,6 @@ views:
       # ── Section 1: Right Now ──────────────────────────────────────────
       - type: vertical-stack
         cards:
-          - type: markdown
-            content: "## Right Now"
-
           - type: horizontal-stack
             cards:
               - type: gauge
@@ -71,8 +68,8 @@ views:
                     color: green
 
           - type: markdown
-            title: Smart Status
             content: |
+              ### Smart Status
               {% set rate = states('sensor.octopus_energy_OCTOPUS_IMPORT_current_rate') | float(0) %}
               {% set carbon_index = states('sensor.CARBON_national_index') %}
               {% set battery_soc = states('sensor.SOLAX_battery_state_of_charge') | float(0) %}
@@ -120,10 +117,8 @@ views:
       - type: vertical-stack
         cards:
           - type: markdown
-            content: "## Yesterday's Review"
-
-          - type: markdown
             content: |
+              ### Yesterday's Summary
               {% set consumption = states('sensor.octopus_energy_OCTOPUS_IMPORT_previous_consumption') | float(0) %}
               {% set cost = states('sensor.octopus_energy_OCTOPUS_IMPORT_previous_cost') | float(0) %}
               {% set intensity = states('sensor.CARBON_national_intensity') | float(0) %}
@@ -133,8 +128,8 @@ views:
               | {{ consumption | round(1) }}kWh | £{{ '%.2f' | format(cost) }} | {{ est_co2 | round(0) | int }}g ({{ (est_co2 / 1000) | round(2) }}kg) |
 
           - type: markdown
-            title: Carbon Analysis
             content: |
+              ### Yesterday's Carbon Analysis
               {% set consumption = states('sensor.octopus_energy_OCTOPUS_IMPORT_previous_consumption') | float(0) %}
               {% set intensity = states('sensor.CARBON_national_intensity') | float(0) %}
               {% set index = states('sensor.CARBON_national_index') %}
@@ -156,8 +151,8 @@ views:
               {% endif %}
 
           - type: markdown
-            title: Net Cost
             content: |
+              ### Yesterday's Net Cost
               {% set import_cost = states('sensor.octopus_energy_OCTOPUS_IMPORT_previous_cost') %}
               {% set has_data = import_cost not in ['unknown', 'unavailable'] %}
               {% if has_data %}
@@ -183,10 +178,8 @@ views:
       - type: vertical-stack
         cards:
           - type: markdown
-            content: "## Tomorrow's Outlook"
-
-          - type: markdown
             content: |
+              ### Tomorrow's Outlook
               {% set solar_today = states('sensor.solcast_pv_forecast_forecast_today') | float(0) %}
               {% set solar_tomorrow = states('sensor.solcast_pv_forecast_forecast_tomorrow') | float(0) %}
               {% set lowest_carbon = states('sensor.CARBON_lowest_forecast_intensity') | float(0) %}
@@ -195,8 +188,8 @@ views:
               | {{ solar_today | round(1) }}kWh | {{ solar_tomorrow | round(1) }}kWh | {{ lowest_carbon | round(0) | int }} gCO2/kWh |
 
           - type: markdown
-            title: Recommendation
             content: |
+              ### Tomorrow's Recommendation
               {% set solar_tomorrow = states('sensor.solcast_pv_forecast_forecast_tomorrow') | float(0) %}
               {% set solar_today = states('sensor.solcast_pv_forecast_forecast_today') | float(0) %}
               {% set lowest_carbon = states('sensor.CARBON_lowest_forecast_intensity') | float(0) %}
@@ -221,8 +214,8 @@ views:
               {% endif %}
 
           - type: markdown
-            title: Carbon Forecast
             content: |
+              ### Carbon Forecast
               {% set current = states('sensor.CARBON_national_intensity') | float(0) %}
               {% set index = states('sensor.CARBON_national_index') %}
               {% set low_carbon = states('sensor.CARBON_low_carbon_percentage') | float(0) %}
@@ -241,11 +234,8 @@ views:
       - type: vertical-stack
         cards:
           - type: markdown
-            content: "## Energy Ratios"
-
-          - type: markdown
-            title: Self-Consumption & Export
             content: |
+              ### Self-Consumption & Export
               {% set import_kwh = states('sensor.octopus_energy_OCTOPUS_IMPORT_previous_consumption') | float(0) %}
               {% set export_kwh = states('sensor.octopus_energy_OCTOPUS_EXPORT_export_previous_consumption') | float(0) %}
               {% set pv_today = states('sensor.SOLAX_today_pv_energy') | float(0) %}
@@ -265,8 +255,8 @@ views:
               {% endif %}
 
           - type: markdown
-            title: Grid Carbon Split
             content: |
+              ### Grid Carbon Split
               {% set low_carbon = states('sensor.CARBON_low_carbon_percentage') | float(0) %}
               {% set fossil = states('sensor.CARBON_fossil_percentage') | float(0) %}
               | Source | Share |
@@ -277,9 +267,6 @@ views:
       # ── Section 5: Weekly Trends ──────────────────────────────────────
       - type: vertical-stack
         cards:
-          - type: markdown
-            content: "## Weekly Trends"
-
           - type: statistics-graph
             title: PV Generation & Consumption (7 days)
             entities:

--- a/dashboards/energy-intelligence.yaml
+++ b/dashboards/energy-intelligence.yaml
@@ -17,7 +17,35 @@ views:
     path: energy-intelligence
     icon: mdi:flash-alert
     cards:
-      # ── Section 1: Right Now ──────────────────────────────────────────
+      # ── Section 1: Yesterday's Summary ─────────────────────────────────
+      - type: markdown
+        content: |
+          ### Yesterday's Summary
+          {% set import_cost = states('sensor.octopus_energy_OCTOPUS_IMPORT_previous_cost') %}
+          {% set has_data = import_cost not in ['unknown', 'unavailable'] %}
+          {% if has_data %}
+          {% set consumption = states('sensor.octopus_energy_OCTOPUS_IMPORT_previous_consumption') | float(0) %}
+          {% set ic = import_cost | float(0) %}
+          {% set export_revenue = states('sensor.octopus_energy_OCTOPUS_EXPORT_export_previous_cost') | float(0) %}
+          {% set gas_cost = states('sensor.octopus_energy_OCTOPUS_GAS_gas_previous_cost') | float(0) %}
+          {% set elec_standing = states('sensor.octopus_energy_OCTOPUS_IMPORT_standing_charge') | float(0) / 100 %}
+          {% set gas_standing = states('sensor.octopus_energy_OCTOPUS_GAS_gas_standing_charge') | float(0) / 100 %}
+          {% set net = ic - export_revenue + gas_cost + elec_standing + gas_standing %}
+          {% set co2_g = states('input_number.yesterday_co2_grams') | float(0) %}
+          | | |
+          |---|---:|
+          | **Consumption** | {{ consumption | round(1) }} kWh |
+          | **CO2 footprint** | {{ co2_g | round(0) | int }}g ({{ (co2_g / 1000) | round(2) }}kg) |
+          | **Net daily cost** | **£{{ '%.2f' | format(net) }}** |
+          | Electricity import | £{{ '%.2f' | format(ic) }} |
+          | Export revenue | -£{{ '%.2f' | format(export_revenue) }} |
+          | Gas | £{{ '%.2f' | format(gas_cost) }} |
+          | Standing charges | £{{ '%.2f' | format(elec_standing + gas_standing) }} |
+          {% else %}
+          *Awaiting yesterday's consumption data.*
+          {% endif %}
+
+      # ── Section 2: Right Now ──────────────────────────────────────────
       - type: vertical-stack
         cards:
           - type: horizontal-stack
@@ -118,96 +146,70 @@ views:
               | **Solar forecast (now)** | {{ solar_now | round(0) | int }} W |
               | **Solar remaining today** | {{ solar_remaining | round(1) }} kWh |
 
-      # ── Section 2: Yesterday's Review ──────────────────────────────────
-      - type: vertical-stack
-        cards:
-          - type: markdown
-            content: |
-              ### Yesterday's Summary
-              {% set import_cost = states('sensor.octopus_energy_OCTOPUS_IMPORT_previous_cost') %}
-              {% set has_data = import_cost not in ['unknown', 'unavailable'] %}
-              {% if has_data %}
-              {% set consumption = states('sensor.octopus_energy_OCTOPUS_IMPORT_previous_consumption') | float(0) %}
-              {% set ic = import_cost | float(0) %}
-              {% set export_revenue = states('sensor.octopus_energy_OCTOPUS_EXPORT_export_previous_cost') | float(0) %}
-              {% set gas_cost = states('sensor.octopus_energy_OCTOPUS_GAS_gas_previous_cost') | float(0) %}
-              {% set elec_standing = states('sensor.octopus_energy_OCTOPUS_IMPORT_standing_charge') | float(0) / 100 %}
-              {% set gas_standing = states('sensor.octopus_energy_OCTOPUS_GAS_gas_standing_charge') | float(0) / 100 %}
-              {% set net = ic - export_revenue + gas_cost + elec_standing + gas_standing %}
-              {% set co2_g = states('input_number.yesterday_co2_grams') | float(0) %}
-              | | |
-              |---|---:|
-              | **Consumption** | {{ consumption | round(1) }} kWh |
-              | **CO2 footprint** | {{ co2_g | round(0) | int }}g ({{ (co2_g / 1000) | round(2) }}kg) |
-              | **Net daily cost** | **£{{ '%.2f' | format(net) }}** |
-              | Electricity import | £{{ '%.2f' | format(ic) }} |
-              | Export revenue | -£{{ '%.2f' | format(export_revenue) }} |
-              | Gas | £{{ '%.2f' | format(gas_cost) }} |
-              | Standing charges | £{{ '%.2f' | format(elec_standing + gas_standing) }} |
-              {% else %}
-              *Awaiting yesterday's consumption data.*
-              {% endif %}
-
       # ── Section 3: Tomorrow's Outlook ──────────────────────────────────
-      - type: vertical-stack
-        cards:
-          - type: markdown
-            content: |
-              ### Tomorrow's Outlook
-              {% set solar_today = states('sensor.solcast_pv_forecast_forecast_today') | float(0) %}
-              {% set solar_tomorrow = states('sensor.solcast_pv_forecast_forecast_tomorrow') | float(0) %}
-              {% set lowest_carbon = states('sensor.CARBON_lowest_forecast_intensity') | float(0) %}
-              {% set peak_tomorrow = states('sensor.solcast_pv_forecast_peak_forecast_tomorrow') | float(0) %}
-              | Solar Today | Solar Tomorrow | Lowest Carbon |
-              |:-----------:|:--------------:|:-------------:|
-              | {{ solar_today | round(1) }}kWh | {{ solar_tomorrow | round(1) }}kWh (peak {{ (peak_tomorrow / 1000) | round(1) }}kW) | {{ lowest_carbon | round(0) | int }} gCO2/kWh |
+      - type: markdown
+        content: |
+          ### Tomorrow's Outlook
+          {% set solar_today = states('sensor.solcast_pv_forecast_forecast_today') | float(0) %}
+          {% set solar_tomorrow = states('sensor.solcast_pv_forecast_forecast_tomorrow') | float(0) %}
+          {% set lowest_carbon = states('sensor.CARBON_lowest_forecast_intensity') | float(0) %}
+          {% set peak_tomorrow = states('sensor.solcast_pv_forecast_peak_forecast_tomorrow') | float(0) %}
+          {% set battery_soc = states('sensor.SOLAX_battery_state_of_charge') | float(0) %}
+          {% set hour = now().hour %}
+          {% set good_solar = solar_tomorrow > 15 %}
+          {% set moderate_solar = solar_tomorrow > 8 %}
+          {% set clean_grid = lowest_carbon < 150 %}
+          {% set very_clean_grid = lowest_carbon < 100 %}
+          {% set evening = hour >= 20 %}
+          {% set battery_healthy = battery_soc >= 50 %}
+          {% set battery_low = battery_soc < 20 %}
+          | Solar Today | Solar Tomorrow | Lowest Carbon | Battery |
+          |:-----------:|:--------------:|:-------------:|:-------:|
+          | {{ solar_today | round(1) }}kWh | {{ solar_tomorrow | round(1) }}kWh (peak {{ (peak_tomorrow / 1000) | round(1) }}kW) | {{ lowest_carbon | round(0) | int }} gCO2/kWh | {{ battery_soc | round(0) | int }}% |
 
-              {% if solar_tomorrow > 15 %}
-              **Sunny day ahead** — skip overnight charging, solar should cover daytime needs and recharge the battery.
-              {% elif solar_tomorrow > 8 %}
-              **Moderate solar** — consider a partial overnight charge to 50% if battery is low, solar will top up the rest.
-              {% elif solar_tomorrow > 0 %}
-              **Low solar** — charge battery overnight during the cheapest window for best cost savings.
-              {% else %}
-              *Solar forecast not available. Check Solcast integration.*
-              {% endif %}
+          {% if good_solar %}
+          **Sunny day ahead** — solar should cover daytime needs and recharge the battery.
+          {% elif moderate_solar %}
+          **Moderate solar** — solar will help but may not cover everything.
+          {% elif solar_tomorrow > 0 %}
+          **Low solar** — grid will be the primary energy source tomorrow.
+          {% else %}
+          *Solar forecast not available. Check Solcast integration.*
+          {% endif %}
 
-              {% if lowest_carbon < 100 %}
-              Grid will be very clean ({{ lowest_carbon | round(0) | int }}gCO2/kWh) — great time to charge from grid if needed.
-              {% elif lowest_carbon < 200 %}
-              Moderate grid carbon forecast ({{ lowest_carbon | round(0) | int }}gCO2/kWh).
-              {% endif %}
-
-      # ── Section 4: Energy Ratios ──────────────────────────────────────
-      - type: vertical-stack
-        cards:
-          - type: markdown
-            content: |
-              ### Self-Consumption & Export
-              {% set import_kwh = states('sensor.octopus_energy_OCTOPUS_IMPORT_previous_consumption') | float(0) %}
-              {% set export_kwh = states('sensor.octopus_energy_OCTOPUS_EXPORT_export_previous_consumption') | float(0) %}
-              {% set pv_today = states('sensor.SOLAX_today_pv_energy') | float(0) %}
-              {% set total_gen = pv_today if pv_today > 0 else 1 %}
-              {% set self_consumed = total_gen - export_kwh if total_gen > export_kwh else 0 %}
-              {% set self_pct = (self_consumed / total_gen * 100) if total_gen > 0 else 0 %}
-              {% set export_pct = (export_kwh / total_gen * 100) if total_gen > 0 else 0 %}
-              {% if pv_today > 0 %}
-              | Metric | Value |
-              |--------|-------|
-              | **PV generated** | {{ pv_today | round(2) }}kWh |
-              | **Self-consumed** | {{ self_consumed | round(2) }}kWh ({{ self_pct | round(0) | int }}%) |
-              | **Exported** | {{ export_kwh | round(2) }}kWh ({{ export_pct | round(0) | int }}%) |
-              | **Grid import** | {{ import_kwh | round(2) }}kWh |
-              {% else %}
-              *PV generation data will appear once the inverter produces energy today.*
-              {% endif %}
-
-          - type: markdown
-            content: |
-              ### Grid Carbon Split
-              {% set low_carbon = states('sensor.CARBON_low_carbon_percentage') | float(0) %}
-              {% set fossil = states('sensor.CARBON_fossil_percentage') | float(0) %}
-              | Source | Share |
-              |--------|-------|
-              | **Clean energy** | {{ low_carbon | round(1) }}% |
-              | **Fossil fuel** | {{ fossil | round(1) }}% |
+          #### Suggestions
+          {% if good_solar and battery_healthy and evening %}
+          - Battery at {{ battery_soc | round(0) | int }}% with strong solar tomorrow — skip overnight charging, battery should last through the night and solar will fully recharge it.
+          {% elif good_solar and battery_low and evening %}
+          - Battery only {{ battery_soc | round(0) | int }}% — consider a small overnight top-up to ~30% to get through the night, solar will do the rest tomorrow.
+          {% elif good_solar and not evening %}
+          - Strong solar tomorrow — no need to schedule overnight battery charging.
+          {% elif moderate_solar and battery_healthy and evening %}
+          - Battery at {{ battery_soc | round(0) | int }}% should last the night with low overnight demand — partial solar recharge tomorrow will top it up.
+          {% elif moderate_solar and battery_low and evening %}
+          - Battery at {{ battery_soc | round(0) | int }}% is too low to last the night — charge to ~50% overnight, solar will handle the rest.
+          {% elif moderate_solar and not evening %}
+          - Moderate solar tomorrow — consider a partial overnight charge if battery drops below 30% by bedtime.
+          {% elif battery_low %}
+          - Battery at {{ battery_soc | round(0) | int }}% — charge overnight during the cheapest rate window.
+          {% else %}
+          - Low solar forecast — charge battery overnight during cheapest rate window.
+          {% endif %}
+          {% if good_solar and clean_grid %}
+          - Switch EV charger from force/overnight tariff to eco mode — charge with free solar during the day instead of paying for overnight grid power.
+          - Good day to run the washing machine, tumble dryer, or dishwasher during daylight hours — solar will cover it with clean energy.
+          {% elif good_solar %}
+          - Switch EV charger to eco mode — charge from solar during the day rather than overnight grid rates.
+          - Run heavy appliances (washing machine, dishwasher) during daylight hours to use free solar.
+          {% elif moderate_solar and clean_grid %}
+          - Consider eco mode for EV charging to catch daytime solar, but keep overnight as backup if demand is high.
+          - Run appliances mid-morning to early afternoon when PV output peaks.
+          {% elif moderate_solar %}
+          - Schedule washing machine and dishwasher for midday when PV output is strongest.
+          {% elif very_clean_grid %}
+          - Very clean grid forecast ({{ lowest_carbon | round(0) | int }}gCO2/kWh) — charge battery and EV from grid overnight at low carbon intensity.
+          - Run heavy loads whenever convenient — grid carbon is low regardless of time.
+          {% else %}
+          - Keep EV on overnight/force tariff for cheapest charging.
+          - Defer heavy appliance loads to off-peak hours to minimise cost.
+          {% endif %}

--- a/dashboards/octopus-energy.yaml
+++ b/dashboards/octopus-energy.yaml
@@ -96,8 +96,7 @@ views:
               {%- set elec_standing = states('sensor.octopus_energy_ELECTRICITY_METER_standing_charge') | float(0) / 100 -%}
               {%- set gas_standing = states('sensor.octopus_energy_GAS_METER_gas_standing_charge') | float(0) / 100 -%}
               {%- set net = ic - export_revenue + gas_cost + elec_standing + gas_standing -%}
-              {%- set intensity = states('sensor.CARBON_national_intensity') | float(0) -%}
-              {%- set est_co2 = import_kwh * intensity -%}
+              {%- set co2_g = states('input_number.yesterday_co2_grams') | float(0) -%}
               {%- set charges = state_attr('sensor.octopus_energy_ELECTRICITY_METER_previous_cost', 'charges') -%}
               {%- set data_date = as_timestamp(charges[0].start) | timestamp_custom('%A %-d %B') if charges and charges | length > 0 else 'Unknown' %}
               ### {{ data_date }} — £{{ '%.2f' | format(net) }} net
@@ -119,8 +118,8 @@ views:
               | Export | *data pending (24-48h lag)* |
               {%- endif %}
               | Standing charges | £{{ '%.2f' | format(elec_standing + gas_standing) }} |
-              {%- if intensity > 0 %}
-              | Est. CO2 | {{ '%.1f' | format(est_co2 / 1000) }} kg |
+              {%- if co2_g > 0 %}
+              | CO2 footprint | {{ '%.1f' | format(co2_g / 1000) }} kg ({{ co2_g | round(0) | int }}g) |
               {%- endif %}
               {%- else %}
               **Standing charges only: £{{ '%.2f' | format(
@@ -171,24 +170,20 @@ views:
           - type: markdown
             content: |
               ### Yesterday's Carbon Footprint
+              {%- set co2_g = states('input_number.yesterday_co2_grams') | float(0) -%}
               {%- set consumption = states('sensor.octopus_energy_ELECTRICITY_METER_previous_consumption') | float(0) -%}
-              {%- set intensity = states('sensor.CARBON_national_intensity') | float(0) -%}
-              {%- set index = states('sensor.CARBON_national_index') -%}
-              {%- set low_carbon = states('sensor.CARBON_low_carbon_percentage') | float(0) -%}
-              {%- set fossil = states('sensor.CARBON_fossil_percentage') | float(0) -%}
-              {%- if consumption > 0 and intensity > 0 -%}
-              {%- set est_co2 = consumption * intensity %}
+              {%- if co2_g > 0 and consumption > 0 -%}
+              {%- set avg_intensity = co2_g / consumption %}
 
               | | |
               |---|---|
-              | **Est. CO2** | {{ '%.1f' | format(est_co2 / 1000) }} kg ({{ est_co2 | round(0) | int }}g) |
-              | **Grid intensity (now)** | {{ intensity | round(0) | int }} gCO2/kWh ({{ index }}) |
-              | **Low-carbon share** | {{ low_carbon | round(1) }}% |
-              | **Fossil fuel share** | {{ fossil | round(1) }}% |
+              | **CO2 footprint** | {{ '%.1f' | format(co2_g / 1000) }} kg ({{ co2_g | round(0) | int }}g) |
+              | **Avg carbon intensity** | {{ avg_intensity | round(0) | int }} gCO2/kWh |
+              | **Consumption** | {{ consumption | round(1) }} kWh |
 
-              *CO2 estimate uses current grid intensity as proxy for yesterday's average.*
+              *Calculated from half-hourly consumption × half-hourly grid carbon intensity.*
               {%- else %}
-              *Carbon data not yet available.*
+              *Carbon data not yet available. Run calculate_co2.py to update.*
               {%- endif %}
 
           - type: markdown

--- a/dashboards/octopus-energy.yaml
+++ b/dashboards/octopus-energy.yaml
@@ -96,7 +96,8 @@ views:
               {%- set elec_standing = states('sensor.octopus_energy_ELECTRICITY_METER_standing_charge') | float(0) / 100 -%}
               {%- set gas_standing = states('sensor.octopus_energy_GAS_METER_gas_standing_charge') | float(0) / 100 -%}
               {%- set net = ic - export_revenue + gas_cost + elec_standing + gas_standing -%}
-              {%- set carbon = state_attr('sensor.octopus_energy_ENTRY_carbon_correlation', 'carbon_summary') -%}
+              {%- set intensity = states('sensor.CARBON_national_intensity') | float(0) -%}
+              {%- set est_co2 = import_kwh * intensity -%}
               {%- set charges = state_attr('sensor.octopus_energy_ELECTRICITY_METER_previous_cost', 'charges') -%}
               {%- set data_date = as_timestamp(charges[0].start) | timestamp_custom('%A %-d %B') if charges and charges | length > 0 else 'Unknown' %}
               ### {{ data_date }} — £{{ '%.2f' | format(net) }} net
@@ -118,8 +119,8 @@ views:
               | Export | *data pending (24-48h lag)* |
               {%- endif %}
               | Standing charges | £{{ '%.2f' | format(elec_standing + gas_standing) }} |
-              {%- if carbon %}
-              | My CO2 | {{ '%.1f' | format(carbon.total_grams_co2 / 1000) }} kg |
+              {%- if intensity > 0 %}
+              | Est. CO2 | {{ '%.1f' | format(est_co2 / 1000) }} kg |
               {%- endif %}
               {%- else %}
               **Standing charges only: £{{ '%.2f' | format(
@@ -170,16 +171,22 @@ views:
           - type: markdown
             content: |
               ### Yesterday's Carbon Footprint
-              {%- set carbon = state_attr('sensor.octopus_energy_ENTRY_carbon_correlation', 'carbon_summary') -%}
-              {%- if carbon -%}
-              {%- set co2_kg = carbon.total_grams_co2 / 1000 %}
+              {%- set consumption = states('sensor.octopus_energy_ELECTRICITY_METER_previous_consumption') | float(0) -%}
+              {%- set intensity = states('sensor.CARBON_national_intensity') | float(0) -%}
+              {%- set index = states('sensor.CARBON_national_index') -%}
+              {%- set low_carbon = states('sensor.CARBON_low_carbon_percentage') | float(0) -%}
+              {%- set fossil = states('sensor.CARBON_fossil_percentage') | float(0) -%}
+              {%- if consumption > 0 and intensity > 0 -%}
+              {%- set est_co2 = consumption * intensity %}
 
               | | |
               |---|---|
-              | **Total CO2** | {{ '%.1f' | format(co2_kg) }} kg |
-              | **Avg intensity** | {{ carbon.weighted_avg_intensity }} gCO2/kWh |
-              | **High-carbon usage** | {{ '%.1f' | format(carbon.high_carbon_kwh) }} kWh ({{ carbon.high_carbon_pct | int }}%) |
-              | **Low-carbon usage** | {{ '%.1f' | format(carbon.low_carbon_kwh) }} kWh ({{ carbon.low_carbon_pct | int }}%) |
+              | **Est. CO2** | {{ '%.1f' | format(est_co2 / 1000) }} kg ({{ est_co2 | round(0) | int }}g) |
+              | **Grid intensity (now)** | {{ intensity | round(0) | int }} gCO2/kWh ({{ index }}) |
+              | **Low-carbon share** | {{ low_carbon | round(1) }}% |
+              | **Fossil fuel share** | {{ fossil | round(1) }}% |
+
+              *CO2 estimate uses current grid intensity as proxy for yesterday's average.*
               {%- else %}
               *Carbon data not yet available.*
               {%- endif %}

--- a/dashboards/uk-carbon-intensity.yaml
+++ b/dashboards/uk-carbon-intensity.yaml
@@ -39,20 +39,18 @@ views:
             icon: mdi:map-marker-multiple
 
           - type: markdown
-            content: >-
+            content: |
+              ### Comparison
               {% set ri = states('sensor.CARBON_regional_intensity') | float(0) %}
               {% set rx = states('sensor.CARBON_regional_index') %}
               {% set ni = states('sensor.CARBON_national_intensity') | float(0) %}
               {% set nx = states('sensor.CARBON_national_index') %}
               {% set diff = ri - ni %}
-
-
               | | Intensity | Index |
               |--|-----------|-------|
               | **Your Region** | {{ ri | round(0) | int }} gCO2/kWh | {{ rx | replace('_', ' ') | title }} |
               | **National** | {{ ni | round(0) | int }} gCO2/kWh | {{ nx | replace('_', ' ') | title }} |
               | **Difference** | {% if diff > 0 %}+{% endif %}{{ diff | round(0) | int }} | {% if diff > 20 %}Above avg{% elif diff < -20 %}Below avg{% else %}Near avg{% endif %} |
-            title: Comparison
 
           - type: horizontal-stack
             cards:
@@ -95,7 +93,8 @@ views:
                     color: "#E5584F"
 
           - type: markdown
-            content: >-
+            content: |
+              ### Optimal Low-Carbon Window
               {% set lowest = states('sensor.CARBON_lowest_forecast_intensity') | float(0) %}
               {% set start = state_attr('sensor.CARBON_lowest_forecast_intensity', 'optimal_window_start') %}
               {% set end = state_attr('sensor.CARBON_lowest_forecast_intensity', 'optimal_window_end') %}
@@ -106,7 +105,6 @@ views:
               {% else %}
               **Best window:** unavailable
               {% endif %}
-            title: Optimal Low-Carbon Window
 
       # ── Section 3: Energy Sources ──
       - type: grid

--- a/scripts/calculate_co2.py
+++ b/scripts/calculate_co2.py
@@ -1,0 +1,216 @@
+#!/usr/bin/env python3
+"""Calculate yesterday's accurate CO2 footprint.
+
+Correlates Octopus Energy half-hourly consumption data with historical
+half-hourly carbon intensity from the National Grid ESO Carbon Intensity
+API, and stores the result in a Home Assistant input_number helper.
+
+Usage:
+    python3 scripts/calculate_co2.py
+
+Requires: pip install websockets
+"""
+
+from __future__ import annotations
+
+import asyncio
+import json
+import sys
+import urllib.request
+from datetime import datetime
+from pathlib import Path
+
+try:
+    import websockets
+except ImportError:
+    print("ERROR: websockets package required. Install with: pip3 install websockets")
+    sys.exit(1)
+
+HA_URL = "ws://192.168.1.227:8123/api/websocket"
+CARBON_API = "https://api.carbonintensity.org.uk/intensity/date"
+HELPER_ENTITY = "input_number.yesterday_co2_grams"
+HELPER_NAME = "Yesterday CO2 Grams"
+
+
+def load_token() -> str:
+    token_path = Path.home() / ".claude" / "accessToken"
+    if not token_path.exists():
+        print(f"ERROR: Token file not found at {token_path}")
+        sys.exit(1)
+    return token_path.read_text().strip()
+
+
+def fetch_carbon_intensity(date_str: str) -> dict[str, float]:
+    """Fetch half-hourly carbon intensity from the National Grid ESO API.
+
+    Returns a dict mapping ISO start time -> actual intensity (gCO2/kWh).
+    """
+    url = f"{CARBON_API}/{date_str}"
+    req = urllib.request.Request(url, headers={"Accept": "application/json"})
+    with urllib.request.urlopen(req, timeout=10) as resp:
+        data = json.loads(resp.read())
+
+    intensity_map: dict[str, float] = {}
+    for entry in data.get("data", []):
+        start = entry["from"]
+        # Prefer actual intensity, fall back to forecast
+        actual = entry.get("intensity", {}).get("actual")
+        forecast = entry.get("intensity", {}).get("forecast", 0)
+        intensity_map[start] = actual if actual is not None else forecast
+
+    return intensity_map
+
+
+def normalise_timestamp(ts: str) -> str:
+    """Normalise an ISO timestamp to YYYY-MM-DDTHH:MMZ for matching."""
+    dt = datetime.fromisoformat(ts)
+    return dt.strftime("%Y-%m-%dT%H:%MZ")
+
+
+def calculate_co2(
+    charges: list[dict], intensity_map: dict[str, float]
+) -> tuple[float, int, int]:
+    """Calculate total CO2 by correlating consumption with carbon intensity.
+
+    Returns (total_co2_grams, matched_slots, total_slots).
+    """
+    # Normalise intensity map keys
+    normalised = {normalise_timestamp(k): v for k, v in intensity_map.items()}
+
+    total_co2 = 0.0
+    matched = 0
+    for charge in charges:
+        key = normalise_timestamp(charge["start"])
+        intensity = normalised.get(key)
+        if intensity is not None:
+            total_co2 += charge["consumption"] * intensity
+            matched += 1
+
+    return total_co2, matched, len(charges)
+
+
+async def run(token: str) -> None:
+    msg_id = 1
+
+    async def send(ws, payload: dict) -> dict:
+        nonlocal msg_id
+        payload["id"] = msg_id
+        msg_id += 1
+        await ws.send(json.dumps(payload))
+        while True:
+            resp = json.loads(await ws.recv())
+            if resp.get("id") == payload["id"]:
+                return resp
+
+    async with websockets.connect(HA_URL) as ws:
+        # Authenticate
+        await ws.recv()
+        await ws.send(json.dumps({"type": "auth", "access_token": token}))
+        auth_resp = json.loads(await ws.recv())
+        if auth_resp.get("type") != "auth_ok":
+            print(f"ERROR: Authentication failed: {auth_resp}")
+            sys.exit(1)
+        print("Authenticated with Home Assistant")
+
+        # Get all states to find the Octopus previous_cost sensor
+        resp = await send(ws, {"type": "get_states"})
+        if not resp.get("success"):
+            print(f"ERROR: Failed to get states: {resp}")
+            sys.exit(1)
+
+        # Find the import previous_cost sensor (has charges attribute)
+        charges = None
+        sensor_id = None
+        for state in resp["result"]:
+            eid = state["entity_id"]
+            if (
+                "octopus_energy" in eid
+                and "previous_cost" in eid
+                and "export" not in eid
+                and "gas" not in eid
+            ):
+                attrs = state.get("attributes", {})
+                charges = attrs.get("charges", [])
+                sensor_id = eid
+                break
+
+        if not charges:
+            print("ERROR: No Octopus charges data found")
+            sys.exit(1)
+
+        print(f"Found {len(charges)} half-hourly slots from {sensor_id}")
+
+        # Extract the date from the charges
+        data_date = datetime.fromisoformat(charges[0]["start"]).strftime("%Y-%m-%d")
+        print(f"Charges date: {data_date}")
+
+        # Fetch carbon intensity for that date
+        print(f"Fetching carbon intensity from {CARBON_API}/{data_date}")
+        intensity_map = fetch_carbon_intensity(data_date)
+        print(f"Got {len(intensity_map)} half-hourly intensity readings")
+
+        # Calculate CO2
+        total_co2, matched, total = calculate_co2(charges, intensity_map)
+        print(
+            f"Matched {matched}/{total} slots, "
+            f"total CO2: {total_co2:.0f}g ({total_co2 / 1000:.2f}kg)"
+        )
+
+        if matched == 0:
+            print("ERROR: No time slots matched between charges and intensity data")
+            sys.exit(1)
+
+        # Ensure the input_number helper exists
+        resp = await send(ws, {"type": "get_states"})
+        helper_exists = any(
+            s["entity_id"] == HELPER_ENTITY for s in resp["result"]
+        )
+
+        if not helper_exists:
+            print(f"Creating helper {HELPER_ENTITY}")
+            resp = await send(
+                ws,
+                {
+                    "type": "input_number/create",
+                    "name": HELPER_NAME,
+                    "min": 0,
+                    "max": 1000000,
+                    "step": 1,
+                    "mode": "box",
+                    "unit_of_measurement": "g",
+                },
+            )
+            if not resp.get("success"):
+                print(f"ERROR: Failed to create helper: {resp}")
+                sys.exit(1)
+
+        # Set the value
+        resp = await send(
+            ws,
+            {
+                "type": "call_service",
+                "domain": "input_number",
+                "service": "set_value",
+                "service_data": {
+                    "entity_id": HELPER_ENTITY,
+                    "value": round(total_co2),
+                },
+            },
+        )
+        if not resp.get("success"):
+            print(f"ERROR: Failed to set value: {resp}")
+            sys.exit(1)
+
+        print(
+            f"Set {HELPER_ENTITY} = {total_co2:.0f}g "
+            f"({total_co2 / 1000:.2f}kg) for {data_date}"
+        )
+
+
+def main() -> None:
+    token = load_token()
+    asyncio.run(run(token))
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/deploy_carbon_intensity.py
+++ b/scripts/deploy_carbon_intensity.py
@@ -6,6 +6,9 @@ entity registry by matching platform and translation_key, substitutes
 them into the dashboard template, and pushes via lovelace/dashboards/create
 + lovelace/config/save.
 
+Also copies custom Lovelace card JS files to HA's www/ directory via the
+REST API and registers them as Lovelace resources.
+
 Usage:
     python3 scripts/deploy_carbon_intensity.py
 
@@ -33,9 +36,20 @@ except ImportError:
     sys.exit(1)
 
 HA_URL = "ws://192.168.1.227:8123/api/websocket"
+HA_SSH_HOST = "192.168.1.227"
+HA_SSH_PORT = 22222
+HA_SSH_USER = "root"
+HA_SSH_PASSWORD = "deploy2026"
 DASHBOARD_URL_PATH = "uk-carbon-intensity"
 DASHBOARD_TITLE = "UK Carbon Intensity"
 DASHBOARD_ICON = "mdi:molecule-co2"
+
+# Custom Lovelace card JS files to deploy
+CARDS_DIR = Path(__file__).resolve().parent.parent / "cards"
+CUSTOM_CARDS = [
+    "uk-carbon-intensity-card.js",
+    "uk-carbon-comparison-card.js",
+]
 
 # Sensor keys from uk_carbon_intensity sensor.py.
 # These match the translation_key / description key in the integration.
@@ -183,6 +197,52 @@ async def deploy(token: str) -> None:
         if not replacements:
             print("ERROR: Could not identify any UK Carbon Intensity entities")
             sys.exit(1)
+
+        # Deploy custom Lovelace cards via SCP
+        print("\nDeploying custom Lovelace cards via SCP...")
+        for card_file in CUSTOM_CARDS:
+            card_path = CARDS_DIR / card_file
+            if not card_path.exists():
+                print(f"  WARNING: {card_file} not found at {card_path}")
+                continue
+
+            import subprocess
+            result = subprocess.run(
+                [
+                    "sshpass", "-p", HA_SSH_PASSWORD,
+                    "scp", "-o", "StrictHostKeyChecking=no",
+                    "-P", str(HA_SSH_PORT),
+                    str(card_path),
+                    f"{HA_SSH_USER}@{HA_SSH_HOST}:/config/www/",
+                ],
+                capture_output=True,
+                text=True,
+            )
+            if result.returncode == 0:
+                print(f"  Copied {card_file} to /config/www/")
+            else:
+                print(f"  ERROR copying {card_file}: {result.stderr.strip()}")
+
+        # Register custom cards as Lovelace resources
+        print("\nRegistering Lovelace resources...")
+        res_resp = await send(ws, {"type": "lovelace/resources"})
+        existing_resources = res_resp.get("result", []) if res_resp.get("success") else []
+        existing_urls = {r.get("url", "") for r in existing_resources}
+
+        for card_file in CUSTOM_CARDS:
+            resource_url = f"/local/{card_file}"
+            if resource_url in existing_urls:
+                print(f"  {resource_url} already registered")
+            else:
+                reg_resp = await send(ws, {
+                    "type": "lovelace/resources/create",
+                    "url": resource_url,
+                    "res_type": "module",
+                })
+                if reg_resp.get("success"):
+                    print(f"  Registered {resource_url}")
+                else:
+                    print(f"  WARNING: Failed to register {resource_url}: {reg_resp}")
 
         # Generate final config
         template = load_template()

--- a/scripts/deploy_energy_intelligence.py
+++ b/scripts/deploy_energy_intelligence.py
@@ -54,7 +54,6 @@ OCTOPUS_MAP = {
     "OCTOPUS_GAS_gas_previous_cost": r".*(?:gas).*_previous_(?:accumulative_)?cost$",
     "OCTOPUS_GAS_gas_standing_charge": r".*(?:gas).*_(?:current_)?standing_charge$",
     # Entry-level (custom integration only)
-    "OCTOPUS_ENTRY_carbon_correlation": r".*_carbon_correlation$",
     "OCTOPUS_ENTRY_tariff_comparison": r".*_tariff_comparison$",
     "OCTOPUS_ENTRY_solar_estimate": r".*_solar_estimate$",
 }

--- a/scripts/deploy_octopus.py
+++ b/scripts/deploy_octopus.py
@@ -56,14 +56,20 @@ ENTITY_MAP = {
     "GAS_METER_gas_previous_consumption": r".*_gas_previous_consumption$",
     "GAS_METER_gas_previous_cost": r".*_gas_previous_cost$",
     "GAS_METER_gas_standing_charge": r".*_gas_standing_charge$",
-    # Entry-level (custom integration)
-    "ENTRY_carbon_correlation": r".*_carbon_correlation$",
     # Account-level
     "ACCOUNT_tariff_comparison": r".*_tariff_comparison$",
     "ACCOUNT_solar_estimate": r".*_solar_estimate$",
 }
 
 PREFIX = "sensor.octopus_energy_"
+
+# Carbon Intensity sensor keys — matched by translation_key in entity registry
+CARBON_KEYS = [
+    "national_intensity",
+    "national_index",
+    "low_carbon_percentage",
+    "fossil_percentage",
+]
 
 
 def load_token() -> str:
@@ -125,6 +131,36 @@ def discover_entities(entities: list[dict]) -> dict[str, str]:
     return replacements
 
 
+def discover_carbon_entities(entities: list[dict]) -> dict[str, str]:
+    """Discover UK Carbon Intensity entities by translation_key."""
+    carbon_entities = [
+        e for e in entities if e.get("platform") == "uk_carbon_intensity"
+    ]
+
+    if not carbon_entities:
+        print("\nWARNING: No uk_carbon_intensity entities found")
+        return {}
+
+    key_to_entity = {}
+    for e in carbon_entities:
+        tkey = e.get("translation_key")
+        if tkey:
+            key_to_entity[tkey] = e["entity_id"]
+
+    print(f"\nCarbon Intensity: found {len(carbon_entities)} entities")
+    replacements: dict[str, str] = {}
+    for key in CARBON_KEYS:
+        placeholder = f"sensor.CARBON_{key}"
+        real_id = key_to_entity.get(key)
+        if real_id:
+            replacements[placeholder] = real_id
+            print(f"  CARBON_{key} -> {real_id}")
+        else:
+            print(f"  CARBON_{key} -> NOT FOUND")
+
+    return replacements
+
+
 def substitute_template(template: str, replacements: dict[str, str]) -> dict:
     """Replace placeholder entity IDs in the YAML template with real ones."""
     result = template
@@ -133,7 +169,7 @@ def substitute_template(template: str, replacements: dict[str, str]) -> dict:
 
     # Warn about any remaining placeholders
     remaining = re.findall(
-        r"sensor\.octopus_energy_(?:ELECTRICITY_METER|EXPORT_METER|GAS_METER|ENTRY|ACCOUNT)_\w+",
+        r"sensor\.(?:octopus_energy_(?:ELECTRICITY_METER|EXPORT_METER|GAS_METER|ENTRY|ACCOUNT)_\w+|CARBON_\w+)",
         result,
     )
     if remaining:
@@ -181,10 +217,12 @@ async def deploy(token: str) -> None:
             print(f"ERROR: Failed to list entities: {entity_resp}")
             sys.exit(1)
 
-        replacements = discover_entities(entity_resp["result"])
+        all_entities = entity_resp["result"]
+        replacements = discover_entities(all_entities)
         if not replacements:
             print("ERROR: Could not identify any Octopus Energy entities")
             sys.exit(1)
+        replacements.update(discover_carbon_entities(all_entities))
 
         # Generate final config
         template = load_template()


### PR DESCRIPTION
## Summary

- Fixed Carbon Analysis cards that referenced non-existent Octopus `carbon_correlation` sensor — replaced with UK Carbon Intensity data
- Created `calculate_co2.py` for accurate CO2 calculation using half-hourly consumption × half-hourly grid carbon intensity from NESO API
- Replaced truncated entity cards with markdown tables
- Adopted `###` inline markdown headings instead of card `title:` properties
- Merged related cards to reduce card count (Smart Status + Current Readings, three Yesterday's cards, two Tomorrow's cards)
- Reordered Energy Intelligence sections chronologically: Yesterday → Current → Tomorrow
- Added compound suggestions combining solar forecast, grid carbon, battery SOC, and time of day
- Fixed UK Carbon Intensity dashboard broken markdown tables (`>-` → `|`)
- Moved custom Lovelace cards (`uk-carbon-intensity-card.js`, `uk-carbon-comparison-card.js`) from ha-ukcarbon into `cards/` directory
- Updated deploy script to SCP cards to HA `www/` and register as Lovelace resources
- Fixed Octopus Energy dashboard carbon references

## Test plan

- [x] Energy Intelligence dashboard deployed and verified
- [x] Octopus Energy dashboard deployed and verified
- [x] UK Carbon Intensity dashboard deployed and verified
- [x] Custom Lovelace cards rendering correctly
- [x] `calculate_co2.py` tested with real data (48/48 slots matched)

🤖 Generated with [Claude Code](https://claude.com/claude-code)